### PR TITLE
chore(release): version single-source-of-truth, CHANGELOG, EAS versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to the Mobile DOPE app are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2026-07-20
+
+First tagged release. Ships the entire application (113 commits, 23 features, 3 fixes);
+`main` previously held only the initial Expo scaffold.
+
+### Added
+
+- Ballistic curve visualization, wind chart, and Wind Table screen
+- PDF export for calculator results, DOPE logs, and range session summaries
+- DOPE card formats including condensed and night-vision modes
+- Save-to-DOPE-Log quick action, quick adjustment inputs, and distance presets
+- Ammunition comparison mode and chronograph integration for velocity logging
+- Range Session Mode with session tracking and export
+- ShotString, RangeSession, and TargetImage models and repositories
+- Database backup/restore and AppSettings persistence via AsyncStorage
+- Navigation state persistence and model factories for testing
+- Portrait and landscape support with responsive layouts for orientation changes
+- Screen timeout setting and haptic feedback toggle for range use
+
+### Fixed
+
+- **Ballistics drag model** — replaced a hand-tuned constant with the physical
+  point-mass formula, correcting over-predicted drop ([#23], [#24])
+
+### Changed
+
+- Adopted a quality, lint, and security tooling stack; decisions recorded as
+  ADR-007..011 ([#17], [#25])
+- Dependency updates and export/import security hardening ([#21])
+- Pinned the Node floor to 24.15 / npm 11; CI reads `.nvmrc`
+
+### Known limitations
+
+- Test coverage is 18.85% against a declared 70% threshold; enforcement is deferred to a
+  test-backfill effort (ADR-010). The suite passes: 455 passed, 1 skipped.
+- `npm run security:audit` reports high-severity advisories in Expo transitive
+  dependencies with no upstream fix available; re-check on the next Expo bump.
+
+[Unreleased]: https://github.com/karlgroves/mobileDOPE/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/karlgroves/mobileDOPE/releases/tag/v1.0.0
+[#17]: https://github.com/karlgroves/mobileDOPE/issues/17
+[#21]: https://github.com/karlgroves/mobileDOPE/pull/21
+[#23]: https://github.com/karlgroves/mobileDOPE/issues/23
+[#24]: https://github.com/karlgroves/mobileDOPE/pull/24
+[#25]: https://github.com/karlgroves/mobileDOPE/pull/25

--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ errors; missing labels/hints are warnings pending remediation) — see
 that today, so `npm run test:coverage` fails. The threshold is a ratchet target, not a
 gate; see [ADR-010](./docs/adr/010-pragmatic-quality-adoption.md).
 
+## Releases
+
+Version history is in [CHANGELOG.md](./CHANGELOG.md). The user-facing version lives in
+`package.json` only; `app.config.ts` reads it from there, so `npm version` propagates to
+the built app. iOS `buildNumber` / Android `versionCode` are managed by EAS
+(`cli.appVersionSource: "remote"`, `autoIncrement` on the production profile).
+
 ## Contributing
 
 This project uses **Git Flow** and **Conventional Commits**. Branch from `develop`,

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,5 +1,9 @@
 import { ExpoConfig, ConfigContext } from 'expo/config';
 
+// Single source of truth for the user-facing version: `npm version` bumps
+// package.json, and the app picks it up here automatically (see CHANGELOG.md).
+import { version } from './package.json';
+
 export default ({ config }: ConfigContext): ExpoConfig => {
   const env = process.env.APP_ENV || 'development';
 
@@ -7,7 +11,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     ...config,
     name: env === 'production' ? 'Mobile DOPE' : `Mobile DOPE (${env})`,
     slug: 'mobiledope',
-    version: '1.0.0',
+    version,
     orientation: 'default',
     icon: './assets/icon.png',
     userInterfaceStyle: 'dark',

--- a/eas.json
+++ b/eas.json
@@ -1,6 +1,7 @@
 {
   "cli": {
-    "version": ">= 5.0.0"
+    "version": ">= 5.0.0",
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {
@@ -17,6 +18,7 @@
       }
     },
     "production": {
+      "autoIncrement": true,
       "env": {
         "APP_ENV": "production"
       }


### PR DESCRIPTION
Release-metadata follow-ups identified during the v1.0.0 release.

## Changes

- **`app.config.ts` reads `version` from `package.json`.** It previously hardcoded
  `'1.0.0'`, so a `npm version` bump would have changed `package.json` while the built
  app kept reporting the old version to users. Now a single source of truth.
- **EAS remote version management** (`eas.json`): `cli.appVersionSource: "remote"` +
  `autoIncrement` on the `production` profile — Expo's recommended approach. Avoids
  hardcoding `ios.buildNumber` / `android.versionCode`, which were unset and would have
  blocked App Store / Play submissions after the first production build.
- **`CHANGELOG.md`** seeded with the v1.0.0 entry (Keep a Changelog format).
- **README** gains a Releases section documenting the version flow.

## Verification

- `npm version 9.9.9` → `expo config --type public` resolved `9.9.9`; reverted. Proves
  the app version now tracks `package.json`.
- `check`, `format:check`, `type-check` all pass.

## Not included

Test coverage (18.85% vs. the declared 70%) is the remaining follow-up. It's a genuine
test-backfill effort, not a metadata edit, so it's left for a dedicated PR rather than
bundled here.

https://github.com/karlgroves/mobileDOPE/compare/develop...feature/release-metadata