### PR TITLE
chore(lint): adopt @typescript-eslint/naming-convention with carve-outs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -68,6 +68,51 @@ module.exports = {
     ],
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'warn',
+
+    // --- Naming conventions (issue #19) ---
+    // The baseline config suggested in issue #19 produces 289 errors here, none of
+    // which are real naming drift: they are SQLite column names, caliber data keys,
+    // RN Navigation route names, dynamically-looked-up StyleSheet keys, and
+    // function-declared React components. The carve-outs below are what make the
+    // rule enforce casing where it is meaningful without flagging load-bearing
+    // names. Each exists for a measured reason — see the comments before relaxing.
+    '@typescript-eslint/naming-convention': [
+      'error',
+      { selector: 'default', format: ['camelCase'], leadingUnderscore: 'allow' },
+      {
+        selector: 'variable',
+        format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
+        leadingUnderscore: 'allow',
+      },
+      // React components are declared as functions, so the `variable` selector
+      // above never reaches them; without this they fall through to `default`
+      // and every component (DOPELogList, WindTable, ...) errors.
+      { selector: 'function', format: ['camelCase', 'PascalCase'] },
+      { selector: 'parameter', format: ['camelCase'], leadingUnderscore: 'allow' },
+      { selector: 'typeLike', format: ['PascalCase'] },
+      { selector: 'enumMember', format: ['PascalCase', 'UPPER_CASE'] },
+      { selector: 'import', format: ['camelCase', 'PascalCase'] },
+      // snake_case: SQLite row shapes in src/types/database.types.ts mirror the
+      // schema columns. PascalCase: RN Navigation route-name maps.
+      { selector: 'typeProperty', format: ['camelCase', 'snake_case', 'PascalCase'] },
+      // Quoted keys that are not valid identifiers ('.223 Rem' in spinDrift.ts,
+      // '2xl'/'3xl' design-token scales) cannot match any format. The explicit
+      // `format: null` is required: a `filter` alone only removes them from this
+      // entry, after which they fall through to `default` and still error.
+      {
+        selector: ['objectLiteralProperty', 'typeProperty'],
+        format: null,
+        filter: { regex: '^[A-Za-z_$][A-Za-z0-9_$]*$', match: false },
+      },
+      // snake_case here covers StyleSheet keys read via dynamic lookup, e.g.
+      // `styles[\`button_${variant}\`]` in src/components/Button.tsx — renaming
+      // those to camelCase would break the lookup.
+      {
+        selector: 'objectLiteralProperty',
+        format: ['camelCase', 'snake_case', 'PascalCase', 'UPPER_CASE'],
+      },
+    ],
+
     'react/react-in-jsx-scope': 'off',
     'react/prop-types': 'off',
     'react-hooks/rules-of-hooks': 'error',


### PR DESCRIPTION
Closes #19.

Adopts `@typescript-eslint/naming-convention` in `.eslintrc.js`. One file changed,
45 insertions, no source files touched.

## Why this isn't the config from the issue

I measured the issue's suggested baseline against the codebase before adopting it:
**289 errors across 29 files, and none are actual naming drift.** Adopting it verbatim
would have meant ~265 justification comments, which inverts the point of the rule —
real violations would be buried in noise.

| Count | What it actually is | Handling |
| --- | --- | --- |
| 72 | SQLite column names in `src/types/database.types.ts` | `typeProperty` allows `snake_case` |
| 66 | Caliber data keys in `spinDrift.ts` (`.17 HMR`, `.223 Rem`) | `format: null` for non-identifiers |
| 36 | RN Navigation route names in `navigation/types.ts` | `typeProperty` allows `PascalCase` |
| 14 | `styles.button_primary` in `Button.tsx` | `objectLiteralProperty` allows `snake_case` |
| 14 | `validate`, `db`, `initialized` (private members) | requirement not adopted — see below |
| 6 | Function-declared React components | new `function` selector allows `PascalCase` |
| 4 | Deliberate `_`-prefixed unused vars | `leadingUnderscore: 'allow'` |

Two of these are worth surfacing for review.

**`Button.tsx` snake_case is load-bearing.** `src/components/Button.tsx:36-45` does
`styles[\`button_${variant}\`]` / `styles[\`button_${size}\`]`. Renaming those keys to
camelCase breaks the component unless the lookup is rewritten. Not a style problem.

**The 6 component errors are a gap in the baseline config, not in the code.** The
baseline permits `PascalCase` on `variable` but has no `function` entry, so
`export function DOPELogList()` falls through to `default: camelCase`. Any React/RN
project using that baseline hits this.

There was also a subtlety worth recording: my first corrected attempt used only a
`filter` on `objectLiteralProperty` and still left **71 errors** — names excluded by a
filter fall through to the `default` selector rather than being exempted. The paired
explicit `format: null` entry is required. The inline comments in the diff capture this
so it isn't rediscovered later.

## One deliberate omission, flagged for your call

The baseline's `memberLike` + `private` + `leadingUnderscore: 'require'` is **not
adopted**. Enforcing it means renaming ~14 members: `validate` across all 7 models,
`db` / `initialized` / `createTables` / `setDatabaseVersion` in `DatabaseService`, and
`migrations` in `MigrationRunner`. That's a real style choice rather than a bug, and TS
`private` already conveys the intent. Say the word and I'll do the renames in a
follow-up instead.

Similarly, `typeProperty` allows `snake_case` globally. The tighter alternative is a
per-file `overrides` entry scoped to `database.types.ts` and the repository `fromRow`
paths — more precise, more config. Happy to switch if you prefer the narrower version.

## Verification

- `npm run lint` — **0 errors, 0 naming-convention violations** across the whole repo
  (including root config files, which `eslint .` also covers). Warning count unchanged
  at 694, so no new warnings introduced.
- `npm run check` — exits 0.
- `npm test` — 455 passed / 15 suites, unchanged.
- **Negative test:** confirmed the rule actually fires rather than silently passing. A
  scratch file with deliberately malformed names errored as expected on all four
  selectors:

  ```
  Variable name `My_Bad_Name` must match one of the following formats: camelCase, UPPER_CASE, PascalCase
  Function name `Bad_function_name` must match one of the following formats: camelCase, PascalCase
  Parameter name `Some_Param` must match one of the following formats: camelCase
  Interface name `bad_interface_name` must match one of the following formats: PascalCase
  ```

## On the issue's third acceptance criterion

> CI fails when the rule is violated (i.e. lint is part of the pipeline / pre-commit)

Already satisfied with no new workflow: lint runs in `pre-commit` (lint-staged) and
`pre-push` (`npm run check`), plus the existing `pr-check.yml`. That keeps this
consistent with ADR-011's no-new-Actions stance. Rule placed in `.eslintrc.js` per
ADR-007.
