### PR TITLE
chore(ci): remove CodeQL job; correct ADR-011's disable claim

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -56,11 +56,16 @@ jobs:
   # `security-events: write` permission above is still required by the
   # upload-sarif step in owasp-dependency-check below.
 
-  # OWASP Dependency Check (comprehensive - weekly only)
+  # OWASP Dependency Check (comprehensive - manual only)
+  #
+  # Manual-only by design: `819bb51` removed this workflow's `schedule:` trigger and
+  # ADR-011 rules out re-adding scheduled scans. The `github.event_name == 'schedule'`
+  # half of the old condition was therefore unreachable and has been dropped -- run
+  # this from the Actions tab ("Run workflow") when a comprehensive scan is wanted.
   owasp-dependency-check:
     name: OWASP Dependency Check
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v6
 
@@ -97,11 +102,12 @@ jobs:
           sarif_file: reports/dependency-check-report.sarif
         if: always()
 
-  # License compliance check
+  # License compliance check (manual only -- same reasoning as owasp-dependency-check
+  # above; there is also an opt-in local equivalent, `npm run license:check`)
   license-check:
     name: License Compliance
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,23 +42,19 @@ jobs:
           path: npm-audit-results.json
           retention-days: 30
 
-  # CodeQL Analysis (SAST)
-  codeql:
-    name: CodeQL Analysis
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
-        with:
-          languages: javascript-typescript
-          queries: security-and-quality
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
-        with:
-          category: '/language:javascript-typescript'
+  # CodeQL was intentionally removed (see docs/adr/011). Do not re-add it here.
+  #
+  # It previously ran as a `codeql` job on every push and PR to main/develop. Two
+  # earlier commits claimed to disable it -- `ffa8c86` ("Disable CodeQL and
+  # Dependabot") and `819bb51` ("chore(ci): disable CodeQL, Dependabot, scheduled
+  # actions") -- but neither touched this job: `ffa8c86` only deleted
+  # .github/dependabot.yml, and `819bb51` only removed this workflow's `schedule:`
+  # cron. So it kept running for months after it was believed to be off.
+  #
+  # SAST coverage is provided locally instead by `npm run security:semgrep`
+  # (opt-in, per ADR-011's local-gate-first approach). Note the
+  # `security-events: write` permission above is still required by the
+  # upload-sarif step in owasp-dependency-check below.
 
   # OWASP Dependency Check (comprehensive - weekly only)
   owasp-dependency-check:

--- a/docs/adr/011-local-gate-first-no-new-actions.md
+++ b/docs/adr/011-local-gate-first-no-new-actions.md
@@ -17,6 +17,32 @@ lightweight `pr-check.yml` was kept in their place. Issue #17 also states a pref
 "Prefer local gates (Husky hooks) over GitHub Actions where possible to shorten the
 feedback loop and reduce Actions minutes."
 
+### Correction (2026-08-06): CodeQL was never actually disabled
+
+The paragraph above took those two commit messages at face value. Their diffs do not
+match their subjects, and this ADR propagated the error:
+
+- `ffa8c86` "Disable CodeQL and Dependabot" deleted **only** `.github/dependabot.yml`
+  (1 file, 36 deletions). It changed nothing CodeQL-related.
+- `819bb51` "chore(ci): disable CodeQL, Dependabot, scheduled actions" removed **only**
+  the weekly `schedule:` cron from `security.yml`. Its `codeql` job, and that
+  workflow's `push`/`pull_request` triggers on `main`/`develop`, were left intact.
+
+There was never a standalone `codeql.yml`; CodeQL existed only as a job inside
+`security.yml`, which this ADR simultaneously listed among the workflows to keep — an
+internal contradiction with "do not re-enable CodeQL" below. GitHub-side default-setup
+code scanning was separately confirmed `not-configured`, so the workflow job was the
+only source.
+
+Consequence: CodeQL ran on every push and PR to `main`/`develop` from its introduction
+in `148d16b` until 2026-08-06, consuming the Actions minutes this ADR was written to
+conserve. The `codeql` job has now been removed from `security.yml`, making the
+repository's state match this ADR's intent. SAST remains available locally and opt-in
+via `npm run security:semgrep`.
+
+Lesson for future ADRs: verify claims about repository state against diffs, not commit
+subjects.
+
 ## Decision
 
 Honour the maintainer's decision and the issue's stated preference:


### PR DESCRIPTION
Removes the `codeql` job from `security.yml` and corrects the factual claim in ADR-011
that led to it running unnoticed.

## It was never re-enabled — it was never disabled

The job has run on **every push and PR to `main`/`develop` since `148d16b`**, despite two
commits whose subjects say otherwise:

| Commit | Subject claims | Actual diff |
| --- | --- | --- |
| `ffa8c86` (2026-02-11) | "Disable CodeQL and Dependabot" | Deleted **only** `.github/dependabot.yml` (1 file, 36 deletions). Nothing CodeQL-related. |
| `819bb51` (2026-02-13) | "disable CodeQL, Dependabot, scheduled actions"; body says "Disabled CodeQL analysis workflows" | Removed **only** `security.yml`'s weekly `schedule:` cron. The `codeql` job and the `push`/`pull_request` triggers were untouched. |

The weekly *scheduled* scan was genuinely disabled. The *per-push and per-PR* runs never
were. ADR-011 then recorded those subjects as established fact — "the `develop` history
includes the commits ..." — without checking the diffs, so the ADR asserted CodeQL was off
while it consumed exactly the Actions minutes the ADR exists to conserve.

Ruled out as alternative sources: there was never a standalone `codeql.yml` (CodeQL existed
only as this job), and GitHub-side default-setup code scanning reports `not-configured`.

## Changes

**`security.yml`** — remove the `codeql` job, replaced by a comment recording why it is
absent so it does not get re-added by someone reading the ADR's "keep security.yml" line.

Two things deliberately **not** changed:

- **`security-events: write` is retained.** The `upload-sarif` step in
  `owasp-dependency-check` still needs it. It looks removable alongside CodeQL but is not.
- **`github/codeql-action/upload-sarif@v4` stays.** That is the SARIF *upload* action, not
  analysis — unrelated to the job being removed.

**ADR-011** — a dated correction documenting the commit-subject/diff mismatch, plus the
ADR's internal contradiction: it listed `security.yml` among the workflows to keep in sync
while also saying CodeQL must not be re-enabled, and `security.yml` *contained* CodeQL.

## Safety check

No branch protection rule or ruleset requires the "CodeQL Analysis" status check on either
`develop` or `main` (`required_status_checks` is unset on both; `rulesets` is empty), so
removing the job cannot leave PRs unmergeable waiting on a check that no longer runs.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` parses `security.yml`, and the `on:` /
  `jobs:` keys are present — the same three checks `pr-check.yml`'s validator runs.
- Remaining jobs parse as exactly `npm-audit`, `owasp-dependency-check`, `license-check`;
  `codeql` confirmed absent. Confirmed empirically too: PR #31's check list included
  "CodeQL Analysis" and "CodeQL"; this PR's does not.
- `npm run check` exits 0; markdownlint and prettier clean on the ADR.

## Note on SAST coverage

This trades server-side SAST on every push for the local, opt-in
`npm run security:semgrep` (configured with `p/typescript`, `p/javascript`, `p/react`,
`p/owasp-top-ten`, `p/secrets`), consistent with ADR-011's local-gate-first approach. That
is a real reduction in automatic coverage — semgrep only runs when someone runs it. If you
would rather keep SAST running server-side, the alternative is to keep the job and amend
ADR-011 to permit it instead; say so and I will invert this PR.

## Also fixed: unreachable `schedule` conditions

`owasp-dependency-check` and `license-check` were both gated on:

```yaml
if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
```

`819bb51` removed this workflow's `schedule:` trigger, so the first clause can never
evaluate true. The condition read as though a weekly scan still existed when both jobs
were in fact manual-only — which is exactly why they report `skipping` on every push and
PR. Same root commit as the CodeQL problem above: `819bb51` half-applied its own intent.

Narrowed to `github.event_name == 'workflow_dispatch'`, with the "weekly only" comment
corrected to "manual only" and a note recording why the schedule half is gone. Restoring
the cron was **not** the fix — ADR-011 rules out re-adding scheduled scans.

**Behaviour-preserving in both directions:** on push/PR these jobs skipped before and skip
now; on `workflow_dispatch` they ran before and run now. Only the dead clause is gone.

Verified by parsing the file: job conditions are now `owasp-dependency-check ->
workflow_dispatch`, `license-check -> workflow_dispatch`, `npm-audit -> always`, with no
remaining `schedule` reference in any condition.
