### PR TITLE
test(components): wire up the component test runner and land the 8 dormant suites

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -214,6 +214,17 @@ module.exports = {
         'sonarjs/no-duplicate-string': 'off',
         'sonarjs/cognitive-complexity': 'off',
         'jsdoc/require-jsdoc': 'off',
+        // Test fixtures are not shipped UI, and the descriptor rule's autofixer is
+        // actively harmful here: because lint-staged runs `eslint --fix` on staged
+        // files, it silently inserted placeholder `accessibilityLabel="Text input
+        // field"` props into all 15 `<TextInput>` fixtures in TextInput.test.tsx --
+        // altering the components under test and merely converting 15 "missing
+        // descriptor" warnings into 15 "missing hint" warnings. This is the same
+        // hazard `jsdoc/require-jsdoc` carries `enableFixer: false` for above.
+        // Real accessibility remediation happens in `src/` (issue #30, which flagged
+        // this exact decision); linting test fixtures for it buys nothing.
+        'react-native-a11y/has-valid-accessibility-descriptors': 'off',
+        'react-native-a11y/has-accessibility-hint': 'off',
       },
     },
   ],

--- a/__tests__/components/Card.test.tsx
+++ b/__tests__/components/Card.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Text } from 'react-native';
-import { render } from '@testing-library/react-native';
+
 import { Card } from '../../src/components/Card';
+import { renderWithProviders as render } from '../helpers/renderWithProviders';
 
 describe('Card', () => {
   it('should render children correctly', () => {

--- a/__tests__/components/TextInput.test.tsx
+++ b/__tests__/components/TextInput.test.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
 import { TextInput } from '../../src/components/TextInput';
+import { theme } from '../../src/constants/theme';
 import { ThemeProvider } from '../../src/contexts/ThemeContext';
 
 // Wrapper component to provide theme context
@@ -81,11 +84,13 @@ describe('TextInput Component', () => {
     );
 
     const input = getByPlaceholderText('Enter name');
-    expect(input.props.style).toMatchObject(
-      expect.objectContaining({
-        borderColor: expect.any(String),
-      })
-    );
+    // React Native passes `style` through as an array of style objects, so flatten to
+    // the effective style before asserting. Asserting the error colour specifically
+    // (rather than `expect.any(String)`) is what makes this test able to fail: every
+    // state of this input sets *some* borderColor.
+    expect(StyleSheet.flatten(input.props.style)).toMatchObject({
+      borderColor: theme.colors.error,
+    });
   });
 
   it('should render with helper text', () => {
@@ -217,11 +222,10 @@ describe('TextInput Component', () => {
     );
 
     const input = getByPlaceholderText('Enter name');
-    // Minimum touch target should be 44pt (per accessibility guidelines)
-    expect(input.props.style).toMatchObject(
-      expect.objectContaining({
-        minHeight: expect.any(Number),
-      })
-    );
+    // Minimum touch target should be 44pt (per accessibility guidelines).
+    // `style` arrives as an array, so flatten first. Assert the actual guarantee rather
+    // than `expect.any(Number)`, which would pass for a 1pt-tall input.
+    const { minHeight } = StyleSheet.flatten(input.props.style);
+    expect(minHeight).toBeGreaterThanOrEqual(theme.touchTargets.min);
   });
 });

--- a/__tests__/helpers/renderWithProviders.tsx
+++ b/__tests__/helpers/renderWithProviders.tsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react-native';
+import React from 'react';
+
+import { ThemeProvider } from '../../src/contexts/ThemeContext';
+
+import type { RenderOptions } from '@testing-library/react-native';
+import type { ReactElement, ReactNode } from 'react';
+
+/**
+ * Wraps a component in the providers the app supplies at runtime.
+ *
+ * Components that call `useTheme()` throw "useTheme must be used within a
+ * ThemeProvider" when rendered bare, so any component test that touches the theme
+ * must go through this instead of RNTL's `render` directly. Screens (issue #28
+ * phase 6) will need this too.
+ */
+const AllProviders = ({ children }: { children: ReactNode }) => (
+  <ThemeProvider>{children}</ThemeProvider>
+);
+
+/**
+ * Drop-in replacement for `@testing-library/react-native`'s `render` that mounts the
+ * app's provider tree around `ui`.
+ */
+export const renderWithProviders = (
+  ui: ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>
+): ReturnType<typeof render> => render(ui, { wrapper: AllProviders, ...options });

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,26 +1,24 @@
-module.exports = {
+// Two Jest projects, because the two test layers need different transformers.
+//
+// - `unit` runs the pure-TypeScript tests (ballistic math, models, utils) through
+//   ts-jest in a node environment. This is the long-standing setup and stays as it was.
+// - `components` renders React Native components, which needs the jest-expo preset
+//   (RN transform, expo module mocks, react-native testEnvironment). ts-jest in a node
+//   environment cannot do it -- it fails on the first `import` of `react-native`.
+//
+// jest-expo requires jest 29 (it depends on jest 29 internals), which is why the
+// dependency alignment in ADR-012 had to land before this file could be wired up.
+// See issue #28 phase 5.
+const unit = {
+  displayName: 'unit',
   preset: 'ts-jest',
   testEnvironment: 'node',
-  collectCoverageFrom: [
-    'src/**/*.{ts,tsx}',
-    '!src/**/*.d.ts',
-    '!src/**/*.types.ts',
-    '!src/**/__tests__/**',
-  ],
-  coverageThreshold: {
-    global: {
-      branches: 70,
-      functions: 70,
-      lines: 70,
-      statements: 70,
-    },
-  },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   testMatch: ['**/__tests__/unit/**/*.(test|spec).(ts|tsx|js)'],
-  testPathIgnorePatterns: ['/node_modules/', '/android/', '/ios/', '/__tests__/components/'],
+  testPathIgnorePatterns: ['/node_modules/', '/android/', '/ios/'],
   transform: {
     '^.+\\.tsx?$': [
       'ts-jest',
@@ -30,5 +28,40 @@ module.exports = {
         },
       },
     ],
+  },
+};
+
+const components = {
+  displayName: 'components',
+  preset: 'jest-expo',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  testMatch: ['**/__tests__/components/**/*.(test|spec).(ts|tsx)'],
+  testPathIgnorePatterns: ['/node_modules/', '/android/', '/ios/'],
+  // jest.setup.js supplies the expo-sqlite / AsyncStorage mocks these components need.
+  // It existed but was never referenced by any config before this change, so it had
+  // never run.
+  setupFiles: ['<rootDir>/jest.setup.js'],
+};
+
+module.exports = {
+  projects: [unit, components],
+  // Coverage is configured at the root so `jest --coverage` reports across both projects.
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.d.ts',
+    '!src/**/*.types.ts',
+    '!src/**/__tests__/**',
+  ],
+  // NOTE: still the aspirational 70%, which `npm run test:coverage` does not meet.
+  // Making this threshold honest is #28 phase 1 and is intentionally not changed here.
+  coverageThreshold: {
+    global: {
+      branches: 70,
+      functions: 70,
+      lines: 70,
+      statements: 70,
+    },
   },
 };


### PR DESCRIPTION
Issue #28 **phase 5**. The 8 suites in `__tests__/components/` have existed since the test
infrastructure landed but never ran — `jest.config.js` matched only `__tests__/unit/` and
explicitly listed `/__tests__/components/` in `testPathIgnorePatterns`. This wires them up
and fixes the 6 assertions that failed once they actually executed.

**`npm test` goes from 15 suites / 455 tests → 23 suites / 519 tests.**

This only became possible after the SDK 55 + jest 29 alignment in ADR-012, since jest-expo
depends on jest 29 internals.

## Config: two Jest projects

The two layers genuinely need different transformers, so `projects` rather than one config:

- **`unit`** — ts-jest + `node` environment for the pure-TypeScript tests (ballistic math,
  models, utils). Behaviour unchanged; the same 455 tests pass.
- **`components`** — the `jest-expo` preset, supplying the RN transform, expo module mocks
  and RN test environment. ts-jest in a node environment cannot render RN; it dies on the
  first `import` of `react-native`.

`jest.setup.js` is referenced **for the first time**. It existed — and even mocked
`global.__ExpoImportMetaRegistry` — but no config had ever pointed at it, so it had never
run. It supplies the `expo-sqlite` and AsyncStorage mocks the component tests need.

## The 6 failures were test bugs, not component bugs

**Card (4) — `useTheme must be used within a ThemeProvider`.** `Card` calls `useTheme()` but
the test rendered it bare. Added `__tests__/helpers/renderWithProviders.tsx`, which mounts
the app's provider tree. Made it a shared helper rather than an inline wrapper because phase
6's screens will all need it.

**TextInput (2) — style array vs object.** The tests asserted `input.props.style` against an
object, but React Native supplies an **array** of style objects. The components were correct
all along; the expected values were present, just nested:

```
Expected: ObjectContaining {"borderColor": Any<String>}
Received: [{...minHeight: 48...}, {"borderColor": "#f44336", ...}, false, undefined]
```

Fixed with `StyleSheet.flatten`, and **strengthened while there — both assertions were
unfalsifiable as written**:

| Was | Problem | Now |
| --- | --- | --- |
| `borderColor: expect.any(String)` | passed for *any* border colour, including the non-error one | asserts `theme.colors.error` |
| `minHeight: expect.any(Number)` | passed for a 1pt-tall input | asserts `>= theme.touchTargets.min` (44) |

The second one is what the test's own comment already claimed ("Minimum touch target should
be 44pt") but did not check.

## One scope addition, forced by the autofixer

I disabled the two `react-native-a11y` warn-level rules **for `__tests__` only**. This is the
decision #30 explicitly left open, and it became unavoidable here: lint-staged runs
`eslint --fix` on staged files, and the descriptor rule's autofixer silently inserted
placeholder `accessibilityLabel="Text input field"` props into **all 15 `<TextInput>`
fixtures** — altering the components under test, and merely converting 15 "missing
descriptor" warnings into 15 "missing hint" warnings.

That is the same hazard `jsdoc/require-jsdoc` already carries `enableFixer: false` for in
this config ("Do NOT auto-insert empty stubs"). Real a11y remediation stays in `src/` (#30).

## Read the coverage number carefully

Per-directory coverage improves where the component tests land:

| | before | after |
| --- | --- | --- |
| `src/components/` lines | 0% | **18.12%** |
| `src/contexts/` lines | 0% | **76.92%** |

But the **merged global percentage drops**, 19.01% → 16.71% lines. That is a measurement
artifact, not a regression: the two projects instrument differently, so their denominators
differ — **4807 statements under ts-jest vs 4122 under babel-jest** — and the merged map is
not comparable to the old single-project number.

**Consequence for #28 phase 1:** the honest threshold must be computed against the *merged*
figure (16.71% lines / 14.18% statements), not the 19.01% recorded in the issue. I left the
aspirational 70% `coverageThreshold` untouched — it is still fiction, and fixing it is phase
1's job. `npm run check` does not run coverage, so nothing in the day-to-day gate depends on
it.

## Verification

- `npm test` exits 0 — **23 suites, 519 passed / 1 skipped**
- `npm run check` and `npm run type-check` exit 0
- lint 0 errors; warnings **667 → 648**, fully accounted for: −15 from scoping a11y out of
  test fixtures, −4 `import/order` from the autofix on the three touched files
- Confirmed `eslint --fix` no longer mutates the fixtures, and re-checked after the
  pre-commit hook ran that the inserted props did not come back
- `--detectOpenHandles` reports nothing. The "worker process failed to exit gracefully"
  notice is a known jest-expo/RN-runtime quirk, present before this change; the run still
  exits 0

## Not done here

- **Phase 6 (screens)** — still 0% and the largest untested surface.
- **Phase 1 (honest threshold)** — deliberately untouched, but now has a correct baseline.
- `#30`'s count needs a one-off correction (69 → 68 production findings): `RangeScreen.tsx`
  carried 1 a11y warning and was deleted in #33. I'll note that on the issue.
