### PR TITLE
test(coverage): make coverageThreshold an honest ratchet and enforce it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,5 +71,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests
-        run: npm run test
+      # Runs the same suites as `npm test` plus the coverageThreshold ratchet in
+      # jest.config.js, so a coverage regression fails here. Deliberately not added to
+      # `npm run check` (the pre-push gate) -- see #28 phase 1 -- to keep the local
+      # feedback loop fast. This adds a step to an existing workflow rather than a new
+      # workflow, per ADR-011.
+      - name: Run tests with coverage
+        run: npm run test:coverage

--- a/jest.config.js
+++ b/jest.config.js
@@ -54,14 +54,38 @@ module.exports = {
     '!src/**/*.types.ts',
     '!src/**/__tests__/**',
   ],
-  // NOTE: still the aspirational 70%, which `npm run test:coverage` does not meet.
-  // Making this threshold honest is #28 phase 1 and is intentionally not changed here.
+  // A RATCHET, not a target (#28 phase 1). These are floors just below actual coverage,
+  // so `npm run test:coverage` passes today and any regression fails. Previously this
+  // declared 70%, which nothing came close to -- the gate was fiction, so it could not be
+  // run in CI and caught nothing.
+  //
+  // Measured on develop @ 973885c, and verified identical across three consecutive runs:
+  //
+  //   lines      16.71%  (929/5559)   -> floor 16
+  //   statements 14.18%  (999/7044)   -> floor 13
+  //   branches   11.09%  (397/3577)   -> floor 10
+  //   functions  10.77%  (170/1577)   -> floor 10
+  //
+  // Rule for picking each floor: the integer below actual, dropped one further when that
+  // would leave under ~0.5pp of headroom (statements and branches). Every floor therefore
+  // has >= 0.7pp of slack -- roughly 300 lines of new uncovered source -- so landing a
+  // feature slightly ahead of its tests does not break the build, while a real regression
+  // does.
+  //
+  // ONLY EVER RAISE THESE. Phases 2-4 of #28 (services, stores, models) should each
+  // ratchet them up as they land. The >80% goal in CLAUDE.md is the destination, not a
+  // number to declare before it is true.
+  //
+  // Note the percentages are not comparable to the pre-#35 figures (18.8%/19.01%): the
+  // `unit` and `components` projects instrument differently and report different
+  // denominators for the same source (7044 statements merged vs 4807 under ts-jest
+  // alone), so this baseline was re-measured after both projects were wired up.
   coverageThreshold: {
     global: {
-      branches: 70,
-      functions: 70,
-      lines: 70,
-      statements: 70,
+      branches: 10,
+      functions: 10,
+      lines: 16,
+      statements: 13,
     },
   },
 };


### PR DESCRIPTION
Issue #28 **phase 1**. Two files, +37/−8.

`jest.config.js` declared a **70%** `coverageThreshold` that nothing came close to, so
`npm run test:coverage` failed on every run. A gate that cannot pass is a gate nobody can
run — it was kept out of `npm run check` *and* out of CI, so it caught **no** regressions
while appearing to promise 70%.

## The new floors

Measured on `develop` @ `973885c`, verified identical across three consecutive runs:

| metric | actual | floor | headroom |
| --- | --- | --- | --- |
| lines | 16.71% (929/5559) | **16** | 0.71pp |
| statements | 14.18% (999/7044) | **13** | 1.18pp |
| branches | 11.09% (397/3577) | **10** | 1.09pp |
| functions | 10.77% (170/1577) | **10** | 0.77pp |

Rule for each floor: the integer below actual, dropped one further where that would leave
under ~0.5pp of headroom (statements and branches would otherwise have had 0.18pp and
0.09pp). Every floor keeps **≥0.7pp of slack — roughly 300 lines of new uncovered source**
— so landing a feature slightly ahead of its tests doesn't break the build, while a real
regression does.

## Why not 18.8% (the number in the issue title)

Both 18.8% and the 19.01% I reported on #33 **predate #35**, which added the `components`
Jest project. The two projects instrument the same source differently and report different
denominators — **7044 statements merged vs 4807 under ts-jest alone** — so the baseline had
to be re-measured after both were wired up.

Ratcheting from the old figure would have set a threshold the suite cannot meet, recreating
precisely the problem this change exists to fix.

## CI enforcement

The existing **`Tests`** job now runs `npm run test:coverage` instead of `npm run test`, so
a coverage regression fails server-side. This adds a step to an *existing* workflow rather
than a new workflow file, per ADR-011, and costs a few seconds.

Deliberately **not** added to `npm run check` (the pre-push gate), per this phase's own
guidance, to keep the local loop fast.

## Verification

- `npm run test:coverage` **exits 0** — it exited 1 on every run before this
- `npm test` still exits 0: 23 suites, 519 passed / 1 skipped
- **The gate actually enforces, not merely passes.** A threshold that passes could just be
  unenforced, so I mutation-tested it: raising the lines floor to 18 (above the actual
  16.71) fails with `coverage threshold for lines (18%) not met: 16.71%` and exits 1.
  Restored to 16 → exit 0.
- `npm run check` exits 0; prettier clean
- `ci.yml` parses under `python3 yaml.safe_load` with `on:`/`jobs:` intact — the same three
  checks `pr-check.yml`'s validator runs — and the Tests job's steps resolve to
  Checkout / Setup Node / Install / **Run tests with coverage**

## Phase 1's definition of done

From the issue: *"`npm run test:coverage` passes and the threshold is a real, enforced
gate"* — met, and now enforced in CI rather than only available locally.

## Note for phases 2–4

**Only ever raise these.** Services, stores and models should each ratchet the floors up as
they land — `src/services/database/` alone is 0/554 lines, so phase 2 should move these
numbers substantially. The >80% goal in CLAUDE.md is the destination, not a number to
declare before it is true.

Worth considering when phase 2 lands: whether a single global threshold is still the right
shape, or whether per-project/per-directory thresholds would be better — `src/utils/` sits
at ~90% and is currently averaged against screens at 0%, which lets real regressions in
well-covered code hide behind the aggregate.
