### PR TITLE
test(services): add a real-SQLite test harness and cover three repositories

### DIFF
--- a/__tests__/helpers/fixtures.ts
+++ b/__tests__/helpers/fixtures.ts
@@ -1,0 +1,68 @@
+import type { AmmoProfileData } from '../../src/models/AmmoProfile';
+import type { DOPELogData } from '../../src/models/DOPELog';
+import type { EnvironmentSnapshotData } from '../../src/models/EnvironmentSnapshot';
+import type { RifleProfileData } from '../../src/models/RifleProfile';
+
+/**
+ * Valid-by-default entity builders for service-layer tests.
+ *
+ * Each returns data that satisfies every NOT NULL and CHECK constraint in `DB_SCHEMA`, so a
+ * test only has to state the fields it actually cares about. See issue #28 phase 2.
+ */
+
+export const validRifle = (overrides: Partial<RifleProfileData> = {}): RifleProfileData => ({
+  name: 'Tikka T3x',
+  caliber: '.308 Win',
+  barrelLength: 24,
+  twistRate: '1:11',
+  zeroDistance: 100,
+  opticManufacturer: 'Vortex',
+  opticModel: 'Razor HD Gen III',
+  reticleType: 'EBR-7C',
+  clickValueType: 'MIL',
+  clickValue: 0.1,
+  scopeHeight: 1.75,
+  ...overrides,
+});
+
+export const validAmmo = (overrides: Partial<AmmoProfileData> = {}): AmmoProfileData => ({
+  name: '175gr SMK',
+  manufacturer: 'Federal',
+  caliber: '.308 Win',
+  bulletWeight: 175,
+  bulletType: 'Sierra MatchKing',
+  ballisticCoefficientG1: 0.505,
+  ballisticCoefficientG7: 0.258,
+  muzzleVelocity: 2600,
+  ...overrides,
+});
+
+export const validEnvironment = (
+  overrides: Partial<EnvironmentSnapshotData> = {}
+): EnvironmentSnapshotData => ({
+  temperature: 59,
+  humidity: 50,
+  pressure: 29.92,
+  altitude: 1000,
+  windSpeed: 5,
+  windDirection: 90,
+  ...overrides,
+});
+
+/**
+ * DOPE logs are FK-constrained to a rifle, ammo and environment row, so callers must pass
+ * ids that already exist -- the schema enforces this and foreign keys are ON.
+ */
+export const validDopeLog = (
+  ids: { rifleId: number; ammoId: number; environmentId: number },
+  overrides: Partial<DOPELogData> = {}
+): DOPELogData => ({
+  ...ids,
+  distance: 500,
+  distanceUnit: 'yards',
+  elevationCorrection: 3.4,
+  windageCorrection: 0.5,
+  correctionUnit: 'MIL',
+  targetType: 'steel',
+  ...overrides,
+});

--- a/__tests__/helpers/testDatabase.ts
+++ b/__tests__/helpers/testDatabase.ts
@@ -1,0 +1,135 @@
+import { DatabaseSync } from 'node:sqlite';
+
+import databaseService from '../../src/services/database/DatabaseService';
+import { DB_INDEXES, DB_SCHEMA } from '../../src/types/database.types';
+
+/**
+ * A real SQLite database for service-layer tests.
+ *
+ * The repositories are almost entirely SQL, so stubbing `expo-sqlite` with canned return
+ * values would test nothing that matters -- a stub cannot enforce NOT NULL, CHECK
+ * constraints, foreign keys, AUTOINCREMENT or ORDER BY. This instead adapts Node's
+ * built-in `node:sqlite` (available because package.json requires node >= 24.15.0) to
+ * expo-sqlite's async API, so tests run the production DDL from `DB_SCHEMA` against a
+ * real engine, in memory.
+ *
+ * Used by every `__tests__/unit/services/**` suite. See issue #28 phase 2.
+ */
+
+/** expo-sqlite's `SQLiteRunResult`. */
+export interface RunResult {
+  lastInsertRowId: number;
+  changes: number;
+}
+
+/** The subset of expo-sqlite's `SQLiteDatabase` that this codebase actually calls. */
+export interface TestDatabase {
+  execAsync(sql: string): Promise<void>;
+  runAsync(sql: string, params?: readonly unknown[]): Promise<RunResult>;
+  getFirstAsync<T>(sql: string, params?: readonly unknown[]): Promise<T | null>;
+  getAllAsync<T>(sql: string, params?: readonly unknown[]): Promise<T[]>;
+  closeAsync(): Promise<void>;
+}
+
+type BindValue = null | number | string | bigint | Uint8Array;
+
+/**
+ * `node:sqlite` accepts only null/number/string/bigint/Uint8Array. expo-sqlite tolerates
+ * `undefined` (treating it as NULL), and the repositories pass `undefined` for optional
+ * columns, so normalise before binding rather than letting the driver throw.
+ */
+const toBindValue = (value: unknown): BindValue => {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'boolean') return value ? 1 : 0;
+  if (
+    typeof value === 'number' ||
+    typeof value === 'string' ||
+    typeof value === 'bigint' ||
+    value instanceof Uint8Array
+  ) {
+    return value;
+  }
+  // Objects/arrays would bind as garbage; failing loudly beats a silently wrong row.
+  throw new TypeError(`Cannot bind value of type ${typeof value} to SQLite: ${String(value)}`);
+};
+
+const bind = (params: readonly unknown[] = []): BindValue[] => params.map(toBindValue);
+
+/**
+ * Creates an in-memory database with the production schema and indexes applied.
+ * Foreign keys are ON, matching `DatabaseService.initialize()`.
+ */
+export const createTestDatabase = (): TestDatabase => {
+  const db = new DatabaseSync(':memory:');
+  db.exec('PRAGMA foreign_keys = ON;');
+  for (const ddl of Object.values(DB_SCHEMA)) db.exec(ddl);
+  for (const ddl of Object.values(DB_INDEXES)) db.exec(ddl);
+
+  return {
+    execAsync: async (sql) => {
+      db.exec(sql);
+    },
+    runAsync: async (sql, params) => {
+      const result = db.prepare(sql).run(...bind(params));
+      return {
+        lastInsertRowId: Number(result.lastInsertRowid),
+        changes: Number(result.changes),
+      };
+    },
+    getFirstAsync: async <T>(sql: string, params?: readonly unknown[]) =>
+      (db.prepare(sql).get(...bind(params)) as T | undefined) ?? null,
+    getAllAsync: async <T>(sql: string, params?: readonly unknown[]) =>
+      db.prepare(sql).all(...bind(params)) as T[],
+    closeAsync: async () => {
+      db.close();
+    },
+  };
+};
+
+/**
+ * The database handed to `expo-sqlite.openDatabaseAsync` by the mock in each suite.
+ * Module-level because `jest.mock` factories are hoisted and cannot close over test state.
+ */
+let active: TestDatabase | null = null;
+
+/** Stands in for `expo-sqlite`'s `openDatabaseAsync`. */
+export const openDatabaseAsync = async (): Promise<TestDatabase> => {
+  if (!active) {
+    throw new Error('No test database installed. Call installTestDatabase() in beforeEach.');
+  }
+  return active;
+};
+
+/**
+ * `initialize()` and `close()` each log on success. Across a few hundred service tests
+ * that buries real output, so silence just those two calls rather than stubbing
+ * `console.log` for the whole suite (which would also hide logging from code under test).
+ */
+const quietly = async (fn: () => Promise<void>): Promise<void> => {
+  const log = console.log;
+  console.log = () => {};
+  try {
+    await fn();
+  } finally {
+    console.log = log;
+  }
+};
+
+/**
+ * Point `databaseService` at a fresh in-memory database.
+ *
+ * Goes through the real `initialize()`/`close()` rather than poking the singleton's private
+ * fields, so those paths are covered too. Call from `beforeEach` for per-test isolation.
+ */
+export const installTestDatabase = async (): Promise<TestDatabase> => {
+  await quietly(() => databaseService.close());
+  active = createTestDatabase();
+  await quietly(() => databaseService.initialize());
+  return active;
+};
+
+/** Release the active database. Call from `afterEach`. */
+export const uninstallTestDatabase = async (): Promise<void> => {
+  await quietly(() => databaseService.close());
+  active = null;
+};

--- a/__tests__/unit/services/AmmoProfileRepository.test.ts
+++ b/__tests__/unit/services/AmmoProfileRepository.test.ts
@@ -1,0 +1,198 @@
+import ammoProfileRepository from '../../../src/services/database/AmmoProfileRepository';
+import { validAmmo } from '../../helpers/fixtures';
+import { installTestDatabase, uninstallTestDatabase } from '../../helpers/testDatabase';
+
+import type { TestDatabase } from '../../helpers/testDatabase';
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: () => require('../../helpers/testDatabase').openDatabaseAsync(),
+}));
+
+describe('AmmoProfileRepository', () => {
+  let db: TestDatabase;
+
+  beforeEach(async () => {
+    db = await installTestDatabase();
+  });
+
+  afterEach(async () => {
+    await uninstallTestDatabase();
+  });
+
+  describe('create', () => {
+    it('persists the row and returns the assigned id', async () => {
+      const created = await ammoProfileRepository.create(validAmmo());
+
+      expect(created.id).toBeGreaterThan(0);
+
+      const row = await db.getFirstAsync<{ name: string; caliber: string }>(
+        'SELECT name, caliber FROM ammo_profiles WHERE id = ?',
+        [created.id]
+      );
+      expect(row).toEqual({ name: '175gr SMK', caliber: '.308 Win' });
+    });
+
+    it('round-trips the ballistic fields without precision loss', async () => {
+      const data = validAmmo({
+        ballisticCoefficientG1: 0.505,
+        ballisticCoefficientG7: 0.258,
+        muzzleVelocity: 2637,
+        bulletWeight: 175,
+      });
+      const created = await ammoProfileRepository.create(data);
+
+      const fetched = await ammoProfileRepository.getById(created.id as number);
+
+      expect(fetched).toMatchObject({
+        ballisticCoefficientG1: 0.505,
+        ballisticCoefficientG7: 0.258,
+        muzzleVelocity: 2637,
+        bulletWeight: 175,
+      });
+    });
+
+    it('stores omitted optional fields as NULL', async () => {
+      const created = await ammoProfileRepository.create(validAmmo());
+
+      const row = await db.getFirstAsync<{
+        powder_type: string | null;
+        powder_weight: number | null;
+        lot_number: string | null;
+        notes: string | null;
+      }>('SELECT powder_type, powder_weight, lot_number, notes FROM ammo_profiles WHERE id = ?', [
+        created.id,
+      ]);
+
+      expect(row).toEqual({
+        powder_type: null,
+        powder_weight: null,
+        lot_number: null,
+        notes: null,
+      });
+    });
+
+    it('persists supplied optional fields', async () => {
+      const created = await ammoProfileRepository.create(
+        validAmmo({ powderType: 'Varget', powderWeight: 44.5, lotNumber: 'LOT-9' })
+      );
+
+      const fetched = await ammoProfileRepository.getById(created.id as number);
+      expect(fetched).toMatchObject({
+        powderType: 'Varget',
+        powderWeight: 44.5,
+        lotNumber: 'LOT-9',
+      });
+    });
+  });
+
+  describe('getByCaliber', () => {
+    beforeEach(async () => {
+      await ammoProfileRepository.create(validAmmo({ name: 'B 175gr', caliber: '.308 Win' }));
+      await ammoProfileRepository.create(validAmmo({ name: 'A 168gr', caliber: '.308 Win' }));
+      await ammoProfileRepository.create(
+        validAmmo({ name: '140gr ELD', caliber: '6.5 Creedmoor' })
+      );
+    });
+
+    it('returns only the matching caliber, ordered by name', async () => {
+      const results = await ammoProfileRepository.getByCaliber('.308 Win');
+      expect(results.map((a) => a.name)).toEqual(['A 168gr', 'B 175gr']);
+    });
+
+    it('returns an empty array for a caliber with no ammo', async () => {
+      expect(await ammoProfileRepository.getByCaliber('.338 Lapua')).toEqual([]);
+    });
+
+    it('does not match on a partial caliber string', async () => {
+      expect(await ammoProfileRepository.getByCaliber('.308')).toEqual([]);
+    });
+  });
+
+  describe('getAll', () => {
+    it('orders by caliber then name', async () => {
+      await ammoProfileRepository.create(validAmmo({ name: 'Zeta', caliber: '6.5 Creedmoor' }));
+      await ammoProfileRepository.create(validAmmo({ name: 'Beta', caliber: '.308 Win' }));
+      await ammoProfileRepository.create(validAmmo({ name: 'Alpha', caliber: '6.5 Creedmoor' }));
+
+      const results = await ammoProfileRepository.getAll();
+      expect(results.map((a) => `${a.caliber}/${a.name}`)).toEqual([
+        '.308 Win/Beta',
+        '6.5 Creedmoor/Alpha',
+        '6.5 Creedmoor/Zeta',
+      ]);
+    });
+
+    it('returns an empty array when there is no ammo', async () => {
+      expect(await ammoProfileRepository.getAll()).toEqual([]);
+    });
+  });
+
+  describe('update', () => {
+    it('changes only the supplied fields and persists them', async () => {
+      const created = await ammoProfileRepository.create(validAmmo({ notes: 'keep me' }));
+
+      const updated = await ammoProfileRepository.update(created.id as number, {
+        muzzleVelocity: 2700,
+      });
+
+      expect(updated?.muzzleVelocity).toBe(2700);
+      expect(updated?.notes).toBe('keep me');
+
+      const reloaded = await ammoProfileRepository.getById(created.id as number);
+      expect(reloaded?.muzzleVelocity).toBe(2700);
+    });
+
+    it('returns null when the id does not exist', async () => {
+      expect(await ammoProfileRepository.update(4242, { muzzleVelocity: 2700 })).toBeNull();
+    });
+  });
+
+  describe('delete', () => {
+    it('removes the row and reports success', async () => {
+      const created = await ammoProfileRepository.create(validAmmo());
+
+      expect(await ammoProfileRepository.delete(created.id as number)).toBe(true);
+      expect(await ammoProfileRepository.getById(created.id as number)).toBeNull();
+    });
+
+    it('reports failure when the id does not exist', async () => {
+      expect(await ammoProfileRepository.delete(4242)).toBe(false);
+    });
+  });
+
+  describe('search', () => {
+    beforeEach(async () => {
+      await ammoProfileRepository.create(
+        validAmmo({ name: '175gr SMK', manufacturer: 'Federal', caliber: '.308 Win' })
+      );
+      await ammoProfileRepository.create(
+        validAmmo({ name: '140gr ELD-M', manufacturer: 'Hornady', caliber: '6.5 Creedmoor' })
+      );
+    });
+
+    it('matches on manufacturer', async () => {
+      const results = await ammoProfileRepository.search('Hornady');
+      expect(results.map((a) => a.name)).toEqual(['140gr ELD-M']);
+    });
+
+    it('matches on a partial name', async () => {
+      const results = await ammoProfileRepository.search('SMK');
+      expect(results.map((a) => a.name)).toEqual(['175gr SMK']);
+    });
+
+    it('returns an empty array when nothing matches', async () => {
+      expect(await ammoProfileRepository.search('Nosler')).toEqual([]);
+    });
+  });
+
+  describe('count', () => {
+    it('counts rows across calibers', async () => {
+      expect(await ammoProfileRepository.count()).toBe(0);
+
+      await ammoProfileRepository.create(validAmmo({ caliber: '.308 Win' }));
+      await ammoProfileRepository.create(validAmmo({ caliber: '6.5 Creedmoor' }));
+
+      expect(await ammoProfileRepository.count()).toBe(2);
+    });
+  });
+});

--- a/__tests__/unit/services/DOPELogRepository.test.ts
+++ b/__tests__/unit/services/DOPELogRepository.test.ts
@@ -1,0 +1,268 @@
+import ammoProfileRepository from '../../../src/services/database/AmmoProfileRepository';
+import dopeLogRepository from '../../../src/services/database/DOPELogRepository';
+import environmentRepository from '../../../src/services/database/EnvironmentRepository';
+import rifleProfileRepository from '../../../src/services/database/RifleProfileRepository';
+import { validAmmo, validDopeLog, validEnvironment, validRifle } from '../../helpers/fixtures';
+import { installTestDatabase, uninstallTestDatabase } from '../../helpers/testDatabase';
+
+import type { TestDatabase } from '../../helpers/testDatabase';
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: () => require('../../helpers/testDatabase').openDatabaseAsync(),
+}));
+
+describe('DOPELogRepository', () => {
+  let db: TestDatabase;
+  let rifleId: number;
+  let ammoId: number;
+  let environmentId: number;
+
+  /** DOPE logs are FK-constrained, so every test needs real parent rows. */
+  beforeEach(async () => {
+    db = await installTestDatabase();
+    rifleId = (await rifleProfileRepository.create(validRifle())).id as number;
+    ammoId = (await ammoProfileRepository.create(validAmmo())).id as number;
+    environmentId = (await environmentRepository.create(validEnvironment())).id as number;
+  });
+
+  afterEach(async () => {
+    await uninstallTestDatabase();
+  });
+
+  const ids = () => ({ rifleId, ammoId, environmentId });
+
+  describe('create', () => {
+    it('persists the log and returns the assigned id', async () => {
+      const created = await dopeLogRepository.create(validDopeLog(ids()));
+
+      expect(created.id).toBeGreaterThan(0);
+      expect(await dopeLogRepository.count()).toBe(1);
+    });
+
+    it('round-trips the correction values', async () => {
+      const created = await dopeLogRepository.create(
+        validDopeLog(ids(), {
+          distance: 800,
+          elevationCorrection: 6.7,
+          windageCorrection: -1.2,
+          correctionUnit: 'MIL',
+        })
+      );
+
+      const fetched = await dopeLogRepository.getById(created.id as number);
+      expect(fetched).toMatchObject({
+        distance: 800,
+        elevationCorrection: 6.7,
+        windageCorrection: -1.2,
+        correctionUnit: 'MIL',
+      });
+    });
+
+    it('rejects a distance unit outside yards/meters (schema CHECK constraint)', async () => {
+      await expect(
+        dopeLogRepository.create(
+          validDopeLog(ids(), { distanceUnit: 'furlongs' as unknown as 'yards' })
+        )
+      ).rejects.toThrow();
+    });
+
+    it('rejects a correction unit outside MIL/MOA (schema CHECK constraint)', async () => {
+      await expect(
+        dopeLogRepository.create(
+          validDopeLog(ids(), { correctionUnit: 'GRADIANS' as unknown as 'MIL' })
+        )
+      ).rejects.toThrow();
+    });
+
+    it('rejects a log referencing a rifle that does not exist (foreign key)', async () => {
+      await expect(
+        dopeLogRepository.create(validDopeLog({ ...ids(), rifleId: 9999 }))
+      ).rejects.toThrow();
+    });
+
+    it('rejects a log referencing an environment that does not exist (foreign key)', async () => {
+      await expect(
+        dopeLogRepository.create(validDopeLog({ ...ids(), environmentId: 9999 }))
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('foreign key cascade', () => {
+    it('deletes a rifle’s logs when the rifle is deleted (ON DELETE CASCADE)', async () => {
+      await dopeLogRepository.create(validDopeLog(ids()));
+      expect(await dopeLogRepository.count()).toBe(1);
+
+      await rifleProfileRepository.delete(rifleId);
+
+      expect(await dopeLogRepository.count()).toBe(0);
+    });
+
+    it('deletes an ammo profile’s logs when the ammo is deleted (ON DELETE CASCADE)', async () => {
+      await dopeLogRepository.create(validDopeLog(ids()));
+
+      await ammoProfileRepository.delete(ammoId);
+
+      expect(await dopeLogRepository.count()).toBe(0);
+    });
+  });
+
+  describe('getByRifleId / getByAmmoId', () => {
+    it('returns only the logs for the given rifle', async () => {
+      const otherRifleId = (await rifleProfileRepository.create(validRifle({ name: 'Other' })))
+        .id as number;
+
+      await dopeLogRepository.create(validDopeLog(ids(), { distance: 300 }));
+      await dopeLogRepository.create(
+        validDopeLog({ ...ids(), rifleId: otherRifleId }, { distance: 400 })
+      );
+
+      const mine = await dopeLogRepository.getByRifleId(rifleId);
+      expect(mine.map((l) => l.distance)).toEqual([300]);
+    });
+
+    it('returns only the logs for the given ammo', async () => {
+      const otherAmmoId = (await ammoProfileRepository.create(validAmmo({ name: 'Other' })))
+        .id as number;
+
+      await dopeLogRepository.create(validDopeLog(ids(), { distance: 300 }));
+      await dopeLogRepository.create(
+        validDopeLog({ ...ids(), ammoId: otherAmmoId }, { distance: 400 })
+      );
+
+      const mine = await dopeLogRepository.getByAmmoId(ammoId);
+      expect(mine.map((l) => l.distance)).toEqual([300]);
+    });
+
+    it('returns an empty array when the rifle has no logs', async () => {
+      expect(await dopeLogRepository.getByRifleId(rifleId)).toEqual([]);
+    });
+  });
+
+  describe('getAll', () => {
+    it('applies the limit when one is given', async () => {
+      for (const distance of [100, 200, 300, 400]) {
+        await dopeLogRepository.create(validDopeLog(ids(), { distance }));
+      }
+
+      expect(await dopeLogRepository.getAll()).toHaveLength(4);
+      expect(await dopeLogRepository.getAll(2)).toHaveLength(2);
+    });
+  });
+
+  describe('getByRifleAndAmmo', () => {
+    it('requires both ids to match', async () => {
+      const otherAmmoId = (await ammoProfileRepository.create(validAmmo({ name: 'Other' })))
+        .id as number;
+
+      await dopeLogRepository.create(validDopeLog(ids(), { distance: 500 }));
+      await dopeLogRepository.create(
+        validDopeLog({ ...ids(), ammoId: otherAmmoId }, { distance: 600 })
+      );
+
+      const results = await dopeLogRepository.getByRifleAndAmmo(rifleId, ammoId);
+      expect(results.map((l) => l.distance)).toEqual([500]);
+    });
+  });
+
+  describe('getByDistanceRange', () => {
+    beforeEach(async () => {
+      for (const distance of [100, 300, 500, 700]) {
+        await dopeLogRepository.create(validDopeLog(ids(), { distance }));
+      }
+    });
+
+    it('is inclusive of both bounds and ordered by distance ascending', async () => {
+      const results = await dopeLogRepository.getByDistanceRange(rifleId, ammoId, 300, 700);
+      expect(results.map((l) => l.distance)).toEqual([300, 500, 700]);
+    });
+
+    it('returns an empty array when no log falls in the range', async () => {
+      expect(await dopeLogRepository.getByDistanceRange(rifleId, ammoId, 800, 900)).toEqual([]);
+    });
+  });
+
+  describe('update', () => {
+    it('changes only the supplied fields and persists them', async () => {
+      const created = await dopeLogRepository.create(validDopeLog(ids(), { notes: 'first group' }));
+
+      const updated = await dopeLogRepository.update(created.id as number, {
+        elevationCorrection: 4.1,
+      });
+
+      expect(updated?.elevationCorrection).toBe(4.1);
+      expect(updated?.notes).toBe('first group');
+
+      const reloaded = await dopeLogRepository.getById(created.id as number);
+      expect(reloaded?.elevationCorrection).toBe(4.1);
+    });
+
+    it('returns null when the id does not exist', async () => {
+      expect(await dopeLogRepository.update(4242, { elevationCorrection: 1 })).toBeNull();
+    });
+  });
+
+  describe('delete', () => {
+    it('removes the log and reports success', async () => {
+      const created = await dopeLogRepository.create(validDopeLog(ids()));
+
+      expect(await dopeLogRepository.delete(created.id as number)).toBe(true);
+      expect(await dopeLogRepository.getById(created.id as number)).toBeNull();
+    });
+
+    it('reports failure when the id does not exist', async () => {
+      expect(await dopeLogRepository.delete(4242)).toBe(false);
+    });
+  });
+
+  describe('count', () => {
+    it('filters by rifle and by ammo independently', async () => {
+      const otherRifleId = (await rifleProfileRepository.create(validRifle({ name: 'Other' })))
+        .id as number;
+
+      await dopeLogRepository.create(validDopeLog(ids()));
+      await dopeLogRepository.create(validDopeLog(ids()));
+      await dopeLogRepository.create(validDopeLog({ ...ids(), rifleId: otherRifleId }));
+
+      expect(await dopeLogRepository.count()).toBe(3);
+      expect(await dopeLogRepository.count(rifleId)).toBe(2);
+      expect(await dopeLogRepository.count(otherRifleId)).toBe(1);
+      expect(await dopeLogRepository.count(rifleId, ammoId)).toBe(2);
+    });
+  });
+
+  describe('getDOPECurve', () => {
+    it('averages corrections per distance and counts the samples', async () => {
+      await dopeLogRepository.create(
+        validDopeLog(ids(), { distance: 500, elevationCorrection: 3.0, windageCorrection: 0.4 })
+      );
+      await dopeLogRepository.create(
+        validDopeLog(ids(), { distance: 500, elevationCorrection: 3.4, windageCorrection: 0.6 })
+      );
+      await dopeLogRepository.create(
+        validDopeLog(ids(), { distance: 300, elevationCorrection: 1.5, windageCorrection: 0.2 })
+      );
+
+      const curve = await dopeLogRepository.getDOPECurve(rifleId, ammoId);
+
+      // Ordered by distance ascending, one entry per distinct distance.
+      expect(curve.map((p) => p.distance)).toEqual([300, 500]);
+
+      const at500 = curve.find((p) => p.distance === 500);
+      expect(at500?.count).toBe(2);
+      expect(at500?.avgElevation).toBeCloseTo(3.2, 5);
+      expect(at500?.avgWindage).toBeCloseTo(0.5, 5);
+    });
+
+    it('returns an empty curve when the pairing has no logs', async () => {
+      expect(await dopeLogRepository.getDOPECurve(rifleId, ammoId)).toEqual([]);
+    });
+  });
+
+  it('keeps rows isolated between tests', async () => {
+    expect(await dopeLogRepository.count()).toBe(0);
+    const row = await db.getFirstAsync<{ count: number }>(
+      'SELECT COUNT(*) as count FROM dope_logs'
+    );
+    expect(row?.count).toBe(0);
+  });
+});

--- a/__tests__/unit/services/RifleProfileRepository.test.ts
+++ b/__tests__/unit/services/RifleProfileRepository.test.ts
@@ -1,0 +1,175 @@
+import rifleProfileRepository from '../../../src/services/database/RifleProfileRepository';
+import { validRifle } from '../../helpers/fixtures';
+import { installTestDatabase, uninstallTestDatabase } from '../../helpers/testDatabase';
+
+import type { TestDatabase } from '../../helpers/testDatabase';
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: () => require('../../helpers/testDatabase').openDatabaseAsync(),
+}));
+
+describe('RifleProfileRepository', () => {
+  let db: TestDatabase;
+
+  beforeEach(async () => {
+    db = await installTestDatabase();
+  });
+
+  afterEach(async () => {
+    await uninstallTestDatabase();
+  });
+
+  describe('create', () => {
+    it('persists the row and returns the assigned id', async () => {
+      const created = await rifleProfileRepository.create(validRifle());
+
+      expect(created.id).toBeGreaterThan(0);
+
+      const row = await db.getFirstAsync<{ name: string; caliber: string }>(
+        'SELECT name, caliber FROM rifle_profiles WHERE id = ?',
+        [created.id]
+      );
+      expect(row).toEqual({ name: 'Tikka T3x', caliber: '.308 Win' });
+    });
+
+    it('round-trips every field through the database', async () => {
+      const data = validRifle({ notes: 'Match rifle' });
+      const created = await rifleProfileRepository.create(data);
+
+      const fetched = await rifleProfileRepository.getById(created.id as number);
+
+      expect(fetched).not.toBeNull();
+      expect(fetched).toMatchObject({
+        name: data.name,
+        caliber: data.caliber,
+        barrelLength: data.barrelLength,
+        twistRate: data.twistRate,
+        zeroDistance: data.zeroDistance,
+        opticManufacturer: data.opticManufacturer,
+        opticModel: data.opticModel,
+        reticleType: data.reticleType,
+        clickValueType: data.clickValueType,
+        clickValue: data.clickValue,
+        scopeHeight: data.scopeHeight,
+        notes: 'Match rifle',
+      });
+    });
+
+    it('stores omitted notes as NULL rather than the string "undefined"', async () => {
+      const created = await rifleProfileRepository.create(validRifle());
+
+      const row = await db.getFirstAsync<{ notes: string | null }>(
+        'SELECT notes FROM rifle_profiles WHERE id = ?',
+        [created.id]
+      );
+      expect(row?.notes).toBeNull();
+    });
+
+    it('assigns distinct ids to successive rifles', async () => {
+      const first = await rifleProfileRepository.create(validRifle({ name: 'A' }));
+      const second = await rifleProfileRepository.create(validRifle({ name: 'B' }));
+
+      expect(second.id).not.toBe(first.id);
+      expect(await rifleProfileRepository.count()).toBe(2);
+    });
+
+    it('rejects a click value type outside MIL/MOA (schema CHECK constraint)', async () => {
+      await expect(
+        rifleProfileRepository.create(
+          validRifle({ clickValueType: 'GRADIANS' as unknown as 'MIL' })
+        )
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('getById', () => {
+    it('returns null for an id that does not exist', async () => {
+      expect(await rifleProfileRepository.getById(4242)).toBeNull();
+    });
+  });
+
+  describe('getAll', () => {
+    it('returns an empty array when there are no rifles', async () => {
+      expect(await rifleProfileRepository.getAll()).toEqual([]);
+    });
+
+    it('orders results by name ascending', async () => {
+      await rifleProfileRepository.create(validRifle({ name: 'Zephyr' }));
+      await rifleProfileRepository.create(validRifle({ name: 'Alpha' }));
+      await rifleProfileRepository.create(validRifle({ name: 'Mike' }));
+
+      const names = (await rifleProfileRepository.getAll()).map((r) => r.name);
+      expect(names).toEqual(['Alpha', 'Mike', 'Zephyr']);
+    });
+  });
+
+  describe('update', () => {
+    it('changes only the supplied fields', async () => {
+      const created = await rifleProfileRepository.create(validRifle({ notes: 'original' }));
+
+      const updated = await rifleProfileRepository.update(created.id as number, {
+        zeroDistance: 200,
+      });
+
+      expect(updated?.zeroDistance).toBe(200);
+      expect(updated?.name).toBe('Tikka T3x');
+      expect(updated?.notes).toBe('original');
+    });
+
+    it('persists the change rather than only mutating the returned object', async () => {
+      const created = await rifleProfileRepository.create(validRifle());
+
+      await rifleProfileRepository.update(created.id as number, { barrelLength: 26 });
+
+      const reloaded = await rifleProfileRepository.getById(created.id as number);
+      expect(reloaded?.barrelLength).toBe(26);
+    });
+
+    it('returns null when the id does not exist', async () => {
+      expect(await rifleProfileRepository.update(4242, { zeroDistance: 300 })).toBeNull();
+    });
+  });
+
+  describe('delete', () => {
+    it('removes the row and reports success', async () => {
+      const created = await rifleProfileRepository.create(validRifle());
+
+      expect(await rifleProfileRepository.delete(created.id as number)).toBe(true);
+      expect(await rifleProfileRepository.getById(created.id as number)).toBeNull();
+      expect(await rifleProfileRepository.count()).toBe(0);
+    });
+
+    it('reports failure when the id does not exist', async () => {
+      expect(await rifleProfileRepository.delete(4242)).toBe(false);
+    });
+  });
+
+  describe('search', () => {
+    beforeEach(async () => {
+      await rifleProfileRepository.create(validRifle({ name: 'Tikka T3x', caliber: '.308 Win' }));
+      await rifleProfileRepository.create(
+        validRifle({ name: 'Bergara HMR', caliber: '6.5 Creedmoor' })
+      );
+    });
+
+    it('matches on a partial name', async () => {
+      const results = await rifleProfileRepository.search('Tikka');
+      expect(results.map((r) => r.name)).toEqual(['Tikka T3x']);
+    });
+
+    it('matches on a partial caliber', async () => {
+      const results = await rifleProfileRepository.search('Creedmoor');
+      expect(results.map((r) => r.name)).toEqual(['Bergara HMR']);
+    });
+
+    it('returns an empty array when nothing matches', async () => {
+      expect(await rifleProfileRepository.search('Remington')).toEqual([]);
+    });
+  });
+
+  describe('count', () => {
+    it('returns 0 for an empty table', async () => {
+      expect(await rifleProfileRepository.count()).toBe(0);
+    });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -54,38 +54,37 @@ module.exports = {
     '!src/**/*.types.ts',
     '!src/**/__tests__/**',
   ],
-  // A RATCHET, not a target (#28 phase 1). These are floors just below actual coverage,
-  // so `npm run test:coverage` passes today and any regression fails. Previously this
-  // declared 70%, which nothing came close to -- the gate was fiction, so it could not be
-  // run in CI and caught nothing.
+  // A RATCHET, not a target (#28 phases 1-2). These are floors just below actual coverage,
+  // so `npm run test:coverage` passes today and any regression fails. It once declared 70%,
+  // which nothing came close to -- the gate was fiction, so it could not be run in CI and
+  // caught nothing.
   //
-  // Measured on develop @ 973885c, and verified identical across three consecutive runs:
+  // Ratcheted by #28 phase 2 (services layer). Measured after adding the repository suites:
   //
-  //   lines      16.71%  (929/5559)   -> floor 16
-  //   statements 14.18%  (999/7044)   -> floor 13
-  //   branches   11.09%  (397/3577)   -> floor 10
-  //   functions  10.77%  (170/1577)   -> floor 10
+  //   metric       phase 1    now      floor
+  //   lines        16.71%     20.12%   19
+  //   statements   14.18%     17.13%   16
+  //   branches     11.09%     13.14%   12
+  //   functions    10.77%     13.96%   13
   //
-  // Rule for picking each floor: the integer below actual, dropped one further when that
-  // would leave under ~0.5pp of headroom (statements and branches). Every floor therefore
-  // has >= 0.7pp of slack -- roughly 300 lines of new uncovered source -- so landing a
-  // feature slightly ahead of its tests does not break the build, while a real regression
-  // does.
+  // Rule for each floor (unchanged from phase 1): the integer below actual, dropped one
+  // further when that would leave under ~0.5pp of headroom -- which is all four here. Every
+  // floor keeps >= 0.9pp of slack so landing a feature slightly ahead of its tests does not
+  // break the build, while a real regression does.
   //
-  // ONLY EVER RAISE THESE. Phases 2-4 of #28 (services, stores, models) should each
-  // ratchet them up as they land. The >80% goal in CLAUDE.md is the destination, not a
-  // number to declare before it is true.
+  // ONLY EVER RAISE THESE. Services work is not finished: 4 of 7 repositories, plus
+  // MigrationRunner, ExportService and ImportService, are still largely uncovered, so the
+  // remainder of phase 2 should raise these again.
   //
-  // Note the percentages are not comparable to the pre-#35 figures (18.8%/19.01%): the
-  // `unit` and `components` projects instrument differently and report different
-  // denominators for the same source (7044 statements merged vs 4807 under ts-jest
-  // alone), so this baseline was re-measured after both projects were wired up.
+  // Note the percentages are not comparable to pre-#35 figures (18.8%/19.01%): the `unit`
+  // and `components` projects instrument differently and report different denominators for
+  // the same source, so the baseline was re-measured once both were wired up.
   coverageThreshold: {
     global: {
-      branches: 10,
-      functions: 10,
-      lines: 16,
-      statements: 13,
+      branches: 12,
+      functions: 13,
+      lines: 19,
+      statements: 16,
     },
   },
 };


### PR DESCRIPTION
Issue #28 **phase 2, first part**. The services layer was **0% covered** and is the
highest-risk untested surface in the app — it's where data integrity lives.

**`npm test`: 23 suites / 519 tests → 26 suites / 576 tests** (+57).

> [!NOTE]
> **Phase 2 is not finished by this PR.** See "What's left" at the bottom. I'd rather land a
> reviewable harness plus three fully-covered repositories than one sprawling change.

## The harness is the real deliverable

`__tests__/helpers/testDatabase.ts` adapts Node's built-in **`node:sqlite`** to expo-sqlite's
async API, so tests run the production DDL from `DB_SCHEMA` against a **real SQL engine**, in
memory.

Stubbing `expo-sqlite` with canned return values would have tested nothing that matters — the
repositories are almost entirely SQL, and a stub cannot enforce `NOT NULL`, `CHECK`
constraints, foreign keys, `AUTOINCREMENT` or `ORDER BY`. `node:sqlite` is available for free
because `package.json` already requires node ≥ 24.15.0 (ADR-011's floor).

Details worth knowing in review:

- It goes through the **real** `DatabaseService.initialize()`/`close()` via a mocked
  `openDatabaseAsync`, rather than poking the singleton's private fields — so those paths get
  covered too.
- It normalises `undefined` → NULL: expo-sqlite tolerates `undefined` params and the
  repositories pass it for optional columns, but `node:sqlite` rejects it outright.
- It silences **only** `initialize()`/`close()`'s own `console.log`, not `console` globally,
  so logging from code under test still surfaces.

## What the real engine buys us

These assertions are impossible against a stub, and they all pass:

| Behaviour | Asserted |
| --- | --- |
| `CHECK` constraints | out-of-range `click_value_type`, `distance_unit`, `correction_unit` all rejected |
| Foreign keys | a DOPE log pointing at a nonexistent rifle / environment is rejected |
| `ON DELETE CASCADE` | deleting a rifle really does delete its DOPE logs |
| NULL handling | omitted optional columns are NULL, not the string `"undefined"` |
| `ORDER BY` | name-asc, caliber-then-name, distance-asc all verified |
| `AVG`/`GROUP BY` | `getDOPECurve` averages per distance and counts samples |

## Coverage

| repository | statements | branches | functions | lines |
| --- | --- | --- | --- | --- |
| `RifleProfileRepository` | **100%** | **100%** | **100%** | **100%** |
| `AmmoProfileRepository` | **100%** | 95% | **100%** | **100%** |
| `DOPELogRepository` | **100%** | 96% | **100%** | **100%** |

Global, with the floors ratcheted using phase 1's rule (integer below actual, dropped one
further when that would leave under ~0.5pp):

| metric | before | now | floor |
| --- | --- | --- | --- |
| lines | 16.71% | **20.12%** | 19 |
| statements | 14.18% | **17.13%** | 16 |
| branches | 11.09% | **13.14%** | 12 |
| functions | 10.77% | **13.96%** | 13 |

## Verification

- `npm test` exits 0 — 26 suites, 576 passed / 1 skipped
- `npm run test:coverage` exits 0 at the new floors
- **The ratchet still enforces**, not merely passes: raising the lines floor to 22 fails with
  `threshold for lines (22%) not met: 20.12%` and exits 1
- `npm run check` and `npm run type-check` exit 0

## What's left in phase 2

The issue's ~70%-of-services target needs all of this, and each chunk should ratchet the
floors again:

| still uncovered | note |
| --- | --- |
| `EnvironmentRepository` | 24%, and only incidentally — the DOPE-log tests create environments |
| `ShotStringRepository` | 0% |
| `RangeSessionRepository` | 0% |
| `TargetImageRepository` | 0% |
| `MigrationRunner` + the 4 migrations | 0% — worth testing that migrations apply in order and are idempotent |
| `DatabaseService` | 21% — `transaction`, `dropAllTables`, `checkIntegrity`, `getStatistics`, `reset` untouched |
| `ExportService` / `ImportService` | 0% — the issue asks for round-trip tests; these are the largest single files in the layer |

The harness and fixtures make each of these formulaic now, which was the point of doing them
first.
