### PR TITLE
test(services): cover the remaining four repositories; fix a boolean round-trip bug

### DIFF
--- a/__tests__/helpers/fixtures.ts
+++ b/__tests__/helpers/fixtures.ts
@@ -1,7 +1,10 @@
 import type { AmmoProfileData } from '../../src/models/AmmoProfile';
 import type { DOPELogData } from '../../src/models/DOPELog';
 import type { EnvironmentSnapshotData } from '../../src/models/EnvironmentSnapshot';
+import type { RangeSessionData } from '../../src/models/RangeSession';
 import type { RifleProfileData } from '../../src/models/RifleProfile';
+import type { ShotStringData } from '../../src/models/ShotString';
+import type { TargetImageData } from '../../src/models/TargetImage';
 
 /**
  * Valid-by-default entity builders for service-layer tests.
@@ -64,5 +67,42 @@ export const validDopeLog = (
   windageCorrection: 0.5,
   correctionUnit: 'MIL',
   targetType: 'steel',
+  ...overrides,
+});
+
+/** Shot strings are FK-constrained to an ammo profile. */
+export const validShotString = (
+  ammoId: number,
+  overrides: Partial<ShotStringData> = {}
+): ShotStringData => ({
+  ammoId,
+  sessionDate: '2026-08-01',
+  shotNumber: 1,
+  velocity: 2600,
+  temperature: 59,
+  ...overrides,
+});
+
+/** Range sessions are FK-constrained to a rifle, ammo and environment row. */
+export const validRangeSession = (
+  ids: { rifleId: number; ammoId: number; environmentId: number },
+  overrides: Partial<RangeSessionData> = {}
+): RangeSessionData => ({
+  ...ids,
+  startTime: '2026-08-01T09:00:00.000Z',
+  distance: 500,
+  shotCount: 0,
+  coldBoreShot: false,
+  ...overrides,
+});
+
+/**
+ * Target images attach to a DOPE log and/or a range session; both columns are nullable, so
+ * callers pass whichever linkage the test needs.
+ */
+export const validTargetImage = (overrides: Partial<TargetImageData> = {}): TargetImageData => ({
+  imageUri: 'file:///targets/group-1.jpg',
+  targetType: 'paper',
+  poiMarkers: [{ x: 10, y: 20, shotNumber: 1 }],
   ...overrides,
 });

--- a/__tests__/unit/services/EnvironmentRepository.test.ts
+++ b/__tests__/unit/services/EnvironmentRepository.test.ts
@@ -1,0 +1,212 @@
+import environmentRepository from '../../../src/services/database/EnvironmentRepository';
+import { validEnvironment } from '../../helpers/fixtures';
+import { installTestDatabase, uninstallTestDatabase } from '../../helpers/testDatabase';
+
+import type { TestDatabase } from '../../helpers/testDatabase';
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: () => require('../../helpers/testDatabase').openDatabaseAsync(),
+}));
+
+/** Days before now, as the ISO timestamp the schema stores. */
+const daysAgo = (days: number): string => new Date(Date.now() - days * 86_400_000).toISOString();
+
+describe('EnvironmentRepository', () => {
+  let db: TestDatabase;
+
+  beforeEach(async () => {
+    db = await installTestDatabase();
+  });
+
+  afterEach(async () => {
+    await uninstallTestDatabase();
+  });
+
+  /**
+   * Creates a snapshot and back-dates it.
+   *
+   * `EnvironmentRepository.create` omits `timestamp` from its INSERT column list, so the
+   * schema's `DEFAULT (datetime('now'))` always wins and a caller-supplied timestamp is
+   * discarded. Ordering and age-based queries therefore have to be set up with SQL.
+   */
+  const createAged = async (days: number, altitude: number): Promise<void> => {
+    const created = await environmentRepository.create(validEnvironment({ altitude }));
+    await db.runAsync('UPDATE environment_snapshots SET timestamp = ? WHERE id = ?', [
+      daysAgo(days),
+      created.id as number,
+    ]);
+  };
+
+  describe('create', () => {
+    it('persists the snapshot and returns the assigned id', async () => {
+      const created = await environmentRepository.create(validEnvironment());
+
+      expect(created.id).toBeGreaterThan(0);
+      expect(await environmentRepository.count()).toBe(1);
+    });
+
+    it('round-trips the atmospheric fields', async () => {
+      const created = await environmentRepository.create(
+        validEnvironment({
+          temperature: 41.5,
+          humidity: 72,
+          pressure: 28.44,
+          altitude: 6500,
+          windSpeed: 12,
+          windDirection: 315,
+        })
+      );
+
+      const fetched = await environmentRepository.getById(created.id as number);
+      expect(fetched).toMatchObject({
+        temperature: 41.5,
+        humidity: 72,
+        pressure: 28.44,
+        altitude: 6500,
+        windSpeed: 12,
+        windDirection: 315,
+      });
+    });
+
+    it('stores omitted GPS coordinates as NULL', async () => {
+      const created = await environmentRepository.create(validEnvironment());
+
+      const row = await db.getFirstAsync<{
+        latitude: number | null;
+        longitude: number | null;
+      }>('SELECT latitude, longitude FROM environment_snapshots WHERE id = ?', [created.id]);
+      expect(row).toEqual({ latitude: null, longitude: null });
+    });
+
+    it('derives density altitude when it is not supplied', async () => {
+      // EnvironmentSnapshot computes it from pressure/temperature, so it is never NULL.
+      const created = await environmentRepository.create(validEnvironment());
+
+      const row = await db.getFirstAsync<{ density_altitude: number | null }>(
+        'SELECT density_altitude FROM environment_snapshots WHERE id = ?',
+        [created.id]
+      );
+      expect(row?.density_altitude).toEqual(expect.any(Number));
+      expect(created.densityAltitude).toBe(row?.density_altitude);
+    });
+
+    it('persists supplied GPS coordinates', async () => {
+      const created = await environmentRepository.create(
+        validEnvironment({ latitude: 39.7392, longitude: -104.9903, densityAltitude: 7200 })
+      );
+
+      const fetched = await environmentRepository.getById(created.id as number);
+      expect(fetched).toMatchObject({
+        latitude: 39.7392,
+        longitude: -104.9903,
+        densityAltitude: 7200,
+      });
+    });
+  });
+
+  describe('getById', () => {
+    it('returns null for an id that does not exist', async () => {
+      expect(await environmentRepository.getById(4242)).toBeNull();
+    });
+  });
+
+  describe('getAll', () => {
+    it('returns newest first and honours the limit', async () => {
+      await createAged(3, 300);
+      await createAged(1, 100);
+      await createAged(2, 200);
+
+      expect((await environmentRepository.getAll()).map((e) => e.altitude)).toEqual([
+        100, 200, 300,
+      ]);
+      expect(await environmentRepository.getAll(2)).toHaveLength(2);
+    });
+
+    it('returns an empty array when there are no snapshots', async () => {
+      expect(await environmentRepository.getAll()).toEqual([]);
+    });
+  });
+
+  describe('getRecent', () => {
+    it('defaults to at most 10 and caps at the requested count', async () => {
+      for (let i = 0; i < 12; i += 1) {
+        await createAged(i, 100 + i);
+      }
+
+      expect(await environmentRepository.getRecent()).toHaveLength(10);
+      expect(await environmentRepository.getRecent(3)).toHaveLength(3);
+    });
+  });
+
+  describe('getCurrent', () => {
+    it('returns the most recent snapshot', async () => {
+      await createAged(5, 500);
+      await createAged(1, 100);
+
+      expect((await environmentRepository.getCurrent())?.altitude).toBe(100);
+    });
+
+    it('returns null when there are no snapshots', async () => {
+      expect(await environmentRepository.getCurrent()).toBeNull();
+    });
+  });
+
+  describe('update', () => {
+    it('changes only the supplied fields and persists them', async () => {
+      const created = await environmentRepository.create(validEnvironment());
+
+      const updated = await environmentRepository.update(created.id as number, {
+        windSpeed: 18,
+      });
+
+      expect(updated?.windSpeed).toBe(18);
+      expect(updated?.temperature).toBe(59);
+
+      const reloaded = await environmentRepository.getById(created.id as number);
+      expect(reloaded?.windSpeed).toBe(18);
+    });
+
+    it('returns null when the id does not exist', async () => {
+      expect(await environmentRepository.update(4242, { windSpeed: 1 })).toBeNull();
+    });
+  });
+
+  describe('delete', () => {
+    it('removes the snapshot and reports success', async () => {
+      const created = await environmentRepository.create(validEnvironment());
+
+      expect(await environmentRepository.delete(created.id as number)).toBe(true);
+      expect(await environmentRepository.getById(created.id as number)).toBeNull();
+    });
+
+    it('reports failure when the id does not exist', async () => {
+      expect(await environmentRepository.delete(4242)).toBe(false);
+    });
+  });
+
+  describe('deleteOlderThan', () => {
+    it('deletes only snapshots older than the cutoff and reports the count', async () => {
+      await createAged(60, 600);
+      await createAged(45, 450);
+      await createAged(0, 100);
+
+      const deleted = await environmentRepository.deleteOlderThan(30);
+
+      expect(deleted).toBe(2);
+      expect(await environmentRepository.count()).toBe(1);
+    });
+
+    it('deletes nothing when every snapshot is newer than the cutoff', async () => {
+      await createAged(0, 100);
+
+      expect(await environmentRepository.deleteOlderThan(30)).toBe(0);
+      expect(await environmentRepository.count()).toBe(1);
+    });
+  });
+
+  describe('count', () => {
+    it('returns 0 for an empty table', async () => {
+      expect(await environmentRepository.count()).toBe(0);
+    });
+  });
+});

--- a/__tests__/unit/services/RangeSessionRepository.test.ts
+++ b/__tests__/unit/services/RangeSessionRepository.test.ts
@@ -1,0 +1,293 @@
+import ammoProfileRepository from '../../../src/services/database/AmmoProfileRepository';
+import environmentRepository from '../../../src/services/database/EnvironmentRepository';
+import rangeSessionRepository from '../../../src/services/database/RangeSessionRepository';
+import rifleProfileRepository from '../../../src/services/database/RifleProfileRepository';
+import { validAmmo, validEnvironment, validRangeSession, validRifle } from '../../helpers/fixtures';
+import { installTestDatabase, uninstallTestDatabase } from '../../helpers/testDatabase';
+
+import type { TestDatabase } from '../../helpers/testDatabase';
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: () => require('../../helpers/testDatabase').openDatabaseAsync(),
+}));
+
+describe('RangeSessionRepository', () => {
+  let db: TestDatabase;
+  let rifleId: number;
+  let ammoId: number;
+  let environmentId: number;
+
+  beforeEach(async () => {
+    db = await installTestDatabase();
+    rifleId = (await rifleProfileRepository.create(validRifle())).id as number;
+    ammoId = (await ammoProfileRepository.create(validAmmo())).id as number;
+    environmentId = (await environmentRepository.create(validEnvironment())).id as number;
+  });
+
+  afterEach(async () => {
+    await uninstallTestDatabase();
+  });
+
+  const ids = () => ({ rifleId, ammoId, environmentId });
+
+  describe('create', () => {
+    it('persists the session and returns the assigned id', async () => {
+      const created = await rangeSessionRepository.create(validRangeSession(ids()));
+
+      expect(created.id).toBeGreaterThan(0);
+      expect(await rangeSessionRepository.count()).toBe(1);
+    });
+
+    it('stores coldBoreShot as an integer 0/1 and reads it back as a boolean', async () => {
+      const cold = await rangeSessionRepository.create(
+        validRangeSession(ids(), { coldBoreShot: true })
+      );
+      const warm = await rangeSessionRepository.create(
+        validRangeSession(ids(), { coldBoreShot: false })
+      );
+
+      const rows = await db.getAllAsync<{ id: number; cold_bore_shot: number }>(
+        'SELECT id, cold_bore_shot FROM range_sessions ORDER BY id'
+      );
+      expect(rows.map((r) => r.cold_bore_shot)).toEqual([1, 0]);
+
+      expect((await rangeSessionRepository.getById(cold.id as number))?.coldBoreShot).toBe(true);
+      expect((await rangeSessionRepository.getById(warm.id as number))?.coldBoreShot).toBe(false);
+    });
+
+    it('leaves a new session open (no end time)', async () => {
+      const created = await rangeSessionRepository.create(validRangeSession(ids()));
+
+      const row = await db.getFirstAsync<{ end_time: string | null }>(
+        'SELECT end_time FROM range_sessions WHERE id = ?',
+        [created.id]
+      );
+      expect(row?.end_time).toBeNull();
+    });
+
+    it('rejects a session referencing a rifle that does not exist (foreign key)', async () => {
+      await expect(
+        rangeSessionRepository.create(validRangeSession({ ...ids(), rifleId: 9999 }))
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('foreign key cascade', () => {
+    it('deletes a rifle’s sessions when the rifle is deleted', async () => {
+      await rangeSessionRepository.create(validRangeSession(ids()));
+
+      await rifleProfileRepository.delete(rifleId);
+
+      expect(await rangeSessionRepository.count()).toBe(0);
+    });
+  });
+
+  describe('getActive', () => {
+    it('returns only sessions with no end time', async () => {
+      const open = await rangeSessionRepository.create(
+        validRangeSession(ids(), { sessionName: 'open' })
+      );
+      const closed = await rangeSessionRepository.create(
+        validRangeSession(ids(), { sessionName: 'closed' })
+      );
+      await rangeSessionRepository.endSession(closed.id as number);
+
+      const active = await rangeSessionRepository.getActive();
+      expect(active.map((s) => s.id)).toEqual([open.id]);
+    });
+
+    it('returns an empty array when every session has ended', async () => {
+      const created = await rangeSessionRepository.create(validRangeSession(ids()));
+      await rangeSessionRepository.endSession(created.id as number);
+
+      expect(await rangeSessionRepository.getActive()).toEqual([]);
+    });
+  });
+
+  describe('endSession', () => {
+    it('records the supplied end time', async () => {
+      const created = await rangeSessionRepository.create(validRangeSession(ids()));
+
+      const ended = await rangeSessionRepository.endSession(
+        created.id as number,
+        '2026-08-01T17:30:00.000Z'
+      );
+
+      expect(ended?.endTime).toBe('2026-08-01T17:30:00.000Z');
+    });
+
+    it('defaults to now when no end time is given', async () => {
+      const created = await rangeSessionRepository.create(validRangeSession(ids()));
+
+      const ended = await rangeSessionRepository.endSession(created.id as number);
+
+      expect(ended?.endTime).toEqual(expect.any(String));
+      expect(Number.isNaN(Date.parse(ended?.endTime as string))).toBe(false);
+    });
+
+    it('returns null when the id does not exist', async () => {
+      expect(await rangeSessionRepository.endSession(4242)).toBeNull();
+    });
+  });
+
+  describe('incrementShotCount', () => {
+    it('increases the count by one each call and persists it', async () => {
+      const created = await rangeSessionRepository.create(
+        validRangeSession(ids(), { shotCount: 0 })
+      );
+
+      expect(
+        (await rangeSessionRepository.incrementShotCount(created.id as number))?.shotCount
+      ).toBe(1);
+      expect(
+        (await rangeSessionRepository.incrementShotCount(created.id as number))?.shotCount
+      ).toBe(2);
+      expect((await rangeSessionRepository.getById(created.id as number))?.shotCount).toBe(2);
+    });
+
+    it('returns null when the id does not exist', async () => {
+      expect(await rangeSessionRepository.incrementShotCount(4242)).toBeNull();
+    });
+  });
+
+  describe('getByRifleId / getByAmmoId', () => {
+    it('filters by rifle and orders newest first', async () => {
+      const otherRifleId = (await rifleProfileRepository.create(validRifle({ name: 'Other' })))
+        .id as number;
+
+      await rangeSessionRepository.create(
+        validRangeSession(ids(), { startTime: '2026-08-01T09:00:00.000Z', distance: 300 })
+      );
+      await rangeSessionRepository.create(
+        validRangeSession(ids(), { startTime: '2026-08-02T09:00:00.000Z', distance: 600 })
+      );
+      await rangeSessionRepository.create(
+        validRangeSession({ ...ids(), rifleId: otherRifleId }, { distance: 900 })
+      );
+
+      const mine = await rangeSessionRepository.getByRifleId(rifleId);
+      expect(mine.map((s) => s.distance)).toEqual([600, 300]);
+    });
+
+    it('filters by ammo', async () => {
+      const otherAmmoId = (await ammoProfileRepository.create(validAmmo({ name: 'Other' })))
+        .id as number;
+
+      await rangeSessionRepository.create(validRangeSession(ids(), { distance: 300 }));
+      await rangeSessionRepository.create(
+        validRangeSession({ ...ids(), ammoId: otherAmmoId }, { distance: 900 })
+      );
+
+      expect((await rangeSessionRepository.getByAmmoId(ammoId)).map((s) => s.distance)).toEqual([
+        300,
+      ]);
+    });
+  });
+
+  describe('getByDateRange', () => {
+    it('returns only sessions starting within the range', async () => {
+      await rangeSessionRepository.create(
+        validRangeSession(ids(), { startTime: '2026-07-01T09:00:00.000Z', distance: 100 })
+      );
+      await rangeSessionRepository.create(
+        validRangeSession(ids(), { startTime: '2026-08-15T09:00:00.000Z', distance: 500 })
+      );
+
+      const results = await rangeSessionRepository.getByDateRange(
+        '2026-08-01T00:00:00.000Z',
+        '2026-08-31T23:59:59.000Z'
+      );
+      expect(results.map((s) => s.distance)).toEqual([500]);
+    });
+  });
+
+  describe('getColdBoreSessions', () => {
+    it('returns only cold-bore sessions', async () => {
+      await rangeSessionRepository.create(
+        validRangeSession(ids(), { coldBoreShot: true, distance: 100 })
+      );
+      await rangeSessionRepository.create(
+        validRangeSession(ids(), { coldBoreShot: false, distance: 500 })
+      );
+
+      const results = await rangeSessionRepository.getColdBoreSessions();
+      expect(results.map((s) => s.distance)).toEqual([100]);
+    });
+  });
+
+  describe('search', () => {
+    it('matches on session name', async () => {
+      await rangeSessionRepository.create(
+        validRangeSession(ids(), { sessionName: 'Prone practice' })
+      );
+      await rangeSessionRepository.create(validRangeSession(ids(), { sessionName: 'Load dev' }));
+
+      const results = await rangeSessionRepository.search('Prone');
+      expect(results.map((s) => s.sessionName)).toEqual(['Prone practice']);
+    });
+
+    it('returns an empty array when nothing matches', async () => {
+      await rangeSessionRepository.create(validRangeSession(ids(), { sessionName: 'Load dev' }));
+
+      expect(await rangeSessionRepository.search('Nothing')).toEqual([]);
+    });
+  });
+
+  describe('count / countByRifle / getTotalShotCountByRifle', () => {
+    it('counts sessions globally and per rifle', async () => {
+      const otherRifleId = (await rifleProfileRepository.create(validRifle({ name: 'Other' })))
+        .id as number;
+
+      await rangeSessionRepository.create(validRangeSession(ids(), { shotCount: 10 }));
+      await rangeSessionRepository.create(validRangeSession(ids(), { shotCount: 15 }));
+      await rangeSessionRepository.create(
+        validRangeSession({ ...ids(), rifleId: otherRifleId }, { shotCount: 7 })
+      );
+
+      expect(await rangeSessionRepository.count()).toBe(3);
+      expect(await rangeSessionRepository.countByRifle(rifleId)).toBe(2);
+      expect(await rangeSessionRepository.getTotalShotCountByRifle(rifleId)).toBe(25);
+    });
+
+    it('reports a zero total for a rifle with no sessions', async () => {
+      expect(await rangeSessionRepository.getTotalShotCountByRifle(rifleId)).toBe(0);
+    });
+  });
+
+  describe('update', () => {
+    it('changes only the supplied fields and persists them', async () => {
+      const created = await rangeSessionRepository.create(
+        validRangeSession(ids(), { notes: 'keep me', distance: 500 })
+      );
+
+      const updated = await rangeSessionRepository.update(created.id as number, { distance: 800 });
+
+      expect(updated?.distance).toBe(800);
+      expect(updated?.notes).toBe('keep me');
+      expect((await rangeSessionRepository.getById(created.id as number))?.distance).toBe(800);
+    });
+
+    it('returns null when the id does not exist', async () => {
+      expect(await rangeSessionRepository.update(4242, { distance: 1 })).toBeNull();
+    });
+  });
+
+  describe('delete', () => {
+    it('removes the session and reports success', async () => {
+      const created = await rangeSessionRepository.create(validRangeSession(ids()));
+
+      expect(await rangeSessionRepository.delete(created.id as number)).toBe(true);
+      expect(await rangeSessionRepository.getById(created.id as number)).toBeNull();
+    });
+
+    it('reports failure when the id does not exist', async () => {
+      expect(await rangeSessionRepository.delete(4242)).toBe(false);
+    });
+  });
+
+  describe('getAll', () => {
+    it('returns an empty array when there are no sessions', async () => {
+      expect(await rangeSessionRepository.getAll()).toEqual([]);
+    });
+  });
+});

--- a/__tests__/unit/services/ShotStringRepository.test.ts
+++ b/__tests__/unit/services/ShotStringRepository.test.ts
@@ -1,0 +1,211 @@
+import ammoProfileRepository from '../../../src/services/database/AmmoProfileRepository';
+import shotStringRepository from '../../../src/services/database/ShotStringRepository';
+import { validAmmo, validShotString } from '../../helpers/fixtures';
+import { installTestDatabase, uninstallTestDatabase } from '../../helpers/testDatabase';
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: () => require('../../helpers/testDatabase').openDatabaseAsync(),
+}));
+
+describe('ShotStringRepository', () => {
+  let ammoId: number;
+
+  beforeEach(async () => {
+    await installTestDatabase();
+    ammoId = (await ammoProfileRepository.create(validAmmo())).id as number;
+  });
+
+  afterEach(async () => {
+    await uninstallTestDatabase();
+  });
+
+  /** Records a full string of shots for one session date. */
+  const recordString = async (sessionDate: string, velocities: number[]): Promise<void> => {
+    for (const [index, velocity] of velocities.entries()) {
+      await shotStringRepository.create(
+        validShotString(ammoId, { sessionDate, shotNumber: index + 1, velocity })
+      );
+    }
+  };
+
+  describe('create', () => {
+    it('persists the shot and returns the assigned id', async () => {
+      const created = await shotStringRepository.create(validShotString(ammoId));
+
+      expect(created.id).toBeGreaterThan(0);
+      expect(await shotStringRepository.count()).toBe(1);
+    });
+
+    it('rejects a shot referencing an ammo profile that does not exist (foreign key)', async () => {
+      await expect(shotStringRepository.create(validShotString(9999))).rejects.toThrow();
+    });
+  });
+
+  describe('foreign key cascade', () => {
+    it('deletes an ammo profile’s shots when the ammo is deleted', async () => {
+      await recordString('2026-08-01', [2600, 2610]);
+
+      await ammoProfileRepository.delete(ammoId);
+
+      expect(await shotStringRepository.count()).toBe(0);
+    });
+  });
+
+  describe('getByAmmoId', () => {
+    it('orders by session date descending then shot number ascending', async () => {
+      await recordString('2026-07-01', [2500, 2510]);
+      await recordString('2026-08-01', [2600, 2610]);
+
+      const shots = await shotStringRepository.getByAmmoId(ammoId);
+      expect(shots.map((s) => `${s.sessionDate}#${s.shotNumber}`)).toEqual([
+        '2026-08-01#1',
+        '2026-08-01#2',
+        '2026-07-01#1',
+        '2026-07-01#2',
+      ]);
+    });
+
+    it('returns an empty array when the ammo has no shots', async () => {
+      expect(await shotStringRepository.getByAmmoId(ammoId)).toEqual([]);
+    });
+  });
+
+  describe('getBySession', () => {
+    it('returns only that session’s shots, in shot order', async () => {
+      await recordString('2026-07-01', [2500]);
+      await recordString('2026-08-01', [2600, 2610, 2620]);
+
+      const shots = await shotStringRepository.getBySession(ammoId, '2026-08-01');
+      expect(shots.map((s) => s.velocity)).toEqual([2600, 2610, 2620]);
+    });
+  });
+
+  describe('getSessionStatistics', () => {
+    it('computes count, average, extreme spread and standard deviation', async () => {
+      // mean 2600; ES = 2620-2580 = 40; population SD of [2580,2600,2620] = 16.33
+      await recordString('2026-08-01', [2580, 2600, 2620]);
+
+      const stats = await shotStringRepository.getSessionStatistics(ammoId, '2026-08-01');
+
+      expect(stats).toEqual({
+        count: 3,
+        averageVelocity: 2600,
+        extremeSpread: 40,
+        standardDeviation: 16.3,
+        minVelocity: 2580,
+        maxVelocity: 2620,
+      });
+    });
+
+    it('reports zero spread and deviation for a single shot', async () => {
+      await recordString('2026-08-01', [2600]);
+
+      expect(await shotStringRepository.getSessionStatistics(ammoId, '2026-08-01')).toMatchObject({
+        count: 1,
+        averageVelocity: 2600,
+        extremeSpread: 0,
+        standardDeviation: 0,
+      });
+    });
+
+    it('returns null for a session with no shots', async () => {
+      expect(await shotStringRepository.getSessionStatistics(ammoId, '2026-01-01')).toBeNull();
+    });
+  });
+
+  describe('getSessionDates', () => {
+    it('returns distinct dates, newest first', async () => {
+      await recordString('2026-07-01', [2500, 2510]);
+      await recordString('2026-08-01', [2600]);
+
+      expect(await shotStringRepository.getSessionDates(ammoId)).toEqual([
+        '2026-08-01',
+        '2026-07-01',
+      ]);
+    });
+
+    it('returns an empty array when the ammo has no sessions', async () => {
+      expect(await shotStringRepository.getSessionDates(ammoId)).toEqual([]);
+    });
+  });
+
+  describe('getNextShotNumber', () => {
+    it('starts at 1 for an empty session', async () => {
+      expect(await shotStringRepository.getNextShotNumber(ammoId, '2026-08-01')).toBe(1);
+    });
+
+    it('continues from the highest shot number in that session', async () => {
+      await recordString('2026-08-01', [2600, 2610, 2620]);
+
+      expect(await shotStringRepository.getNextShotNumber(ammoId, '2026-08-01')).toBe(4);
+    });
+
+    it('numbers each session independently', async () => {
+      await recordString('2026-07-01', [2500, 2510]);
+
+      expect(await shotStringRepository.getNextShotNumber(ammoId, '2026-08-01')).toBe(1);
+    });
+  });
+
+  describe('update', () => {
+    it('changes only the supplied fields and persists them', async () => {
+      const created = await shotStringRepository.create(
+        validShotString(ammoId, { notes: 'chrono warm-up' })
+      );
+
+      const updated = await shotStringRepository.update(created.id as number, { velocity: 2650 });
+
+      expect(updated?.velocity).toBe(2650);
+      expect(updated?.notes).toBe('chrono warm-up');
+      expect((await shotStringRepository.getById(created.id as number))?.velocity).toBe(2650);
+    });
+
+    it('returns null when the id does not exist', async () => {
+      expect(await shotStringRepository.update(4242, { velocity: 1 })).toBeNull();
+    });
+  });
+
+  describe('delete', () => {
+    it('removes the shot and reports success', async () => {
+      const created = await shotStringRepository.create(validShotString(ammoId));
+
+      expect(await shotStringRepository.delete(created.id as number)).toBe(true);
+      expect(await shotStringRepository.getById(created.id as number)).toBeNull();
+    });
+
+    it('reports failure when the id does not exist', async () => {
+      expect(await shotStringRepository.delete(4242)).toBe(false);
+    });
+  });
+
+  describe('deleteBySession', () => {
+    it('deletes only that session’s shots and reports the count', async () => {
+      await recordString('2026-07-01', [2500, 2510]);
+      await recordString('2026-08-01', [2600, 2610, 2620]);
+
+      expect(await shotStringRepository.deleteBySession(ammoId, '2026-08-01')).toBe(3);
+      expect(await shotStringRepository.countByAmmo(ammoId)).toBe(2);
+    });
+  });
+
+  describe('count / countByAmmo', () => {
+    it('counts globally and per ammo profile', async () => {
+      const otherAmmoId = (await ammoProfileRepository.create(validAmmo({ name: 'Other' })))
+        .id as number;
+
+      await recordString('2026-08-01', [2600, 2610]);
+      await shotStringRepository.create(validShotString(otherAmmoId));
+
+      expect(await shotStringRepository.count()).toBe(3);
+      expect(await shotStringRepository.countByAmmo(ammoId)).toBe(2);
+      expect(await shotStringRepository.countByAmmo(otherAmmoId)).toBe(1);
+    });
+  });
+
+  describe('getAll', () => {
+    it('returns every shot across ammo profiles', async () => {
+      await recordString('2026-08-01', [2600, 2610]);
+      expect(await shotStringRepository.getAll()).toHaveLength(2);
+    });
+  });
+});

--- a/__tests__/unit/services/TargetImageRepository.test.ts
+++ b/__tests__/unit/services/TargetImageRepository.test.ts
@@ -1,0 +1,250 @@
+import ammoProfileRepository from '../../../src/services/database/AmmoProfileRepository';
+import dopeLogRepository from '../../../src/services/database/DOPELogRepository';
+import environmentRepository from '../../../src/services/database/EnvironmentRepository';
+import rangeSessionRepository from '../../../src/services/database/RangeSessionRepository';
+import rifleProfileRepository from '../../../src/services/database/RifleProfileRepository';
+import targetImageRepository from '../../../src/services/database/TargetImageRepository';
+import {
+  validAmmo,
+  validDopeLog,
+  validEnvironment,
+  validRangeSession,
+  validRifle,
+  validTargetImage,
+} from '../../helpers/fixtures';
+import { installTestDatabase, uninstallTestDatabase } from '../../helpers/testDatabase';
+
+import type { TestDatabase } from '../../helpers/testDatabase';
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: () => require('../../helpers/testDatabase').openDatabaseAsync(),
+}));
+
+describe('TargetImageRepository', () => {
+  let db: TestDatabase;
+  let dopeLogId: number;
+  let rangeSessionId: number;
+
+  beforeEach(async () => {
+    db = await installTestDatabase();
+    const rifleId = (await rifleProfileRepository.create(validRifle())).id as number;
+    const ammoId = (await ammoProfileRepository.create(validAmmo())).id as number;
+    const environmentId = (await environmentRepository.create(validEnvironment())).id as number;
+    const ids = { rifleId, ammoId, environmentId };
+    dopeLogId = (await dopeLogRepository.create(validDopeLog(ids))).id as number;
+    rangeSessionId = (await rangeSessionRepository.create(validRangeSession(ids))).id as number;
+  });
+
+  afterEach(async () => {
+    await uninstallTestDatabase();
+  });
+
+  describe('create', () => {
+    it('persists the image and returns the assigned id', async () => {
+      const created = await targetImageRepository.create(validTargetImage({ dopeLogId }));
+
+      expect(created.id).toBeGreaterThan(0);
+      expect(await targetImageRepository.count()).toBe(1);
+    });
+
+    it('serialises POI markers to JSON and reads them back as objects', async () => {
+      const markers = [
+        { x: 10, y: 20, shotNumber: 1 },
+        { x: 12.5, y: 18.25, shotNumber: 2 },
+      ];
+      const created = await targetImageRepository.create(
+        validTargetImage({ dopeLogId, poiMarkers: markers })
+      );
+
+      const row = await db.getFirstAsync<{ poi_markers: string }>(
+        'SELECT poi_markers FROM target_images WHERE id = ?',
+        [created.id]
+      );
+      expect(typeof row?.poi_markers).toBe('string');
+      expect(JSON.parse(row?.poi_markers as string)).toEqual(markers);
+
+      const fetched = await targetImageRepository.getById(created.id as number);
+      expect(fetched?.poiMarkers).toEqual(markers);
+    });
+
+    it('accepts an empty marker list', async () => {
+      const created = await targetImageRepository.create(
+        validTargetImage({ dopeLogId, poiMarkers: [] })
+      );
+
+      expect((await targetImageRepository.getById(created.id as number))?.poiMarkers).toEqual([]);
+    });
+
+    it('can attach to a range session instead of a DOPE log', async () => {
+      const created = await targetImageRepository.create(validTargetImage({ rangeSessionId }));
+
+      const found = await targetImageRepository.getByRangeSessionId(rangeSessionId);
+      expect(found.map((t) => t.id)).toEqual([created.id]);
+    });
+
+    it('rejects an image referencing a DOPE log that does not exist (foreign key)', async () => {
+      await expect(
+        targetImageRepository.create(validTargetImage({ dopeLogId: 9999 }))
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('foreign key cascade', () => {
+    it('deletes a DOPE log’s images when the log is deleted', async () => {
+      await targetImageRepository.create(validTargetImage({ dopeLogId }));
+
+      await dopeLogRepository.delete(dopeLogId);
+
+      expect(await targetImageRepository.count()).toBe(0);
+    });
+
+    it('deletes a range session’s images when the session is deleted', async () => {
+      await targetImageRepository.create(validTargetImage({ rangeSessionId }));
+
+      await rangeSessionRepository.delete(rangeSessionId);
+
+      expect(await targetImageRepository.count()).toBe(0);
+    });
+  });
+
+  describe('getByDopeLogId', () => {
+    it('returns only that log’s images', async () => {
+      await targetImageRepository.create(validTargetImage({ dopeLogId }));
+      await targetImageRepository.create(validTargetImage({ rangeSessionId }));
+
+      expect(await targetImageRepository.getByDopeLogId(dopeLogId)).toHaveLength(1);
+    });
+
+    it('returns an empty array when the log has no images', async () => {
+      expect(await targetImageRepository.getByDopeLogId(dopeLogId)).toEqual([]);
+    });
+  });
+
+  describe('updatePoiMarkers', () => {
+    it('replaces the marker list', async () => {
+      const created = await targetImageRepository.create(validTargetImage({ dopeLogId }));
+      const replacement = [{ x: 1, y: 2 }];
+
+      const updated = await targetImageRepository.updatePoiMarkers(
+        created.id as number,
+        replacement
+      );
+
+      expect(updated?.poiMarkers).toEqual(replacement);
+      expect((await targetImageRepository.getById(created.id as number))?.poiMarkers).toEqual(
+        replacement
+      );
+    });
+  });
+
+  describe('updateGroupSize', () => {
+    it('records the measured group size', async () => {
+      const created = await targetImageRepository.create(validTargetImage({ dopeLogId }));
+
+      const updated = await targetImageRepository.updateGroupSize(created.id as number, 0.75);
+
+      expect(updated?.groupSize).toBe(0.75);
+      expect((await targetImageRepository.getById(created.id as number))?.groupSize).toBe(0.75);
+    });
+  });
+
+  describe('getWithGroupSize', () => {
+    it('returns only images that have a group size recorded', async () => {
+      const measured = await targetImageRepository.create(validTargetImage({ dopeLogId }));
+      await targetImageRepository.create(validTargetImage({ dopeLogId }));
+      await targetImageRepository.updateGroupSize(measured.id as number, 1.25);
+
+      const results = await targetImageRepository.getWithGroupSize();
+      expect(results.map((t) => t.id)).toEqual([measured.id]);
+    });
+  });
+
+  describe('getAverageGroupSizeByDopeLog', () => {
+    it('averages the recorded group sizes for a log', async () => {
+      const first = await targetImageRepository.create(validTargetImage({ dopeLogId }));
+      const second = await targetImageRepository.create(validTargetImage({ dopeLogId }));
+      await targetImageRepository.updateGroupSize(first.id as number, 0.5);
+      await targetImageRepository.updateGroupSize(second.id as number, 1.5);
+
+      expect(await targetImageRepository.getAverageGroupSizeByDopeLog(dopeLogId)).toBeCloseTo(
+        1.0,
+        5
+      );
+    });
+
+    it('returns null when no image for the log has a group size', async () => {
+      await targetImageRepository.create(validTargetImage({ dopeLogId }));
+
+      expect(await targetImageRepository.getAverageGroupSizeByDopeLog(dopeLogId)).toBeNull();
+    });
+  });
+
+  describe('getByTargetType', () => {
+    it('filters by target type', async () => {
+      await targetImageRepository.create(validTargetImage({ dopeLogId, targetType: 'paper' }));
+      await targetImageRepository.create(validTargetImage({ dopeLogId, targetType: 'steel' }));
+
+      const steel = await targetImageRepository.getByTargetType('steel');
+      expect(steel.map((t) => t.targetType)).toEqual(['steel']);
+    });
+  });
+
+  describe('deleteByDopeLogId / deleteByRangeSessionId', () => {
+    it('deletes every image for a DOPE log and reports the count', async () => {
+      await targetImageRepository.create(validTargetImage({ dopeLogId }));
+      await targetImageRepository.create(validTargetImage({ dopeLogId }));
+      await targetImageRepository.create(validTargetImage({ rangeSessionId }));
+
+      expect(await targetImageRepository.deleteByDopeLogId(dopeLogId)).toBe(2);
+      expect(await targetImageRepository.count()).toBe(1);
+    });
+
+    it('deletes every image for a range session and reports the count', async () => {
+      await targetImageRepository.create(validTargetImage({ rangeSessionId }));
+
+      expect(await targetImageRepository.deleteByRangeSessionId(rangeSessionId)).toBe(1);
+      expect(await targetImageRepository.count()).toBe(0);
+    });
+  });
+
+  describe('update', () => {
+    it('changes only the supplied fields and persists them', async () => {
+      const created = await targetImageRepository.create(
+        validTargetImage({ dopeLogId, targetType: 'paper' })
+      );
+
+      const updated = await targetImageRepository.update(created.id as number, {
+        imageUri: 'file:///targets/updated.jpg',
+      });
+
+      expect(updated?.imageUri).toBe('file:///targets/updated.jpg');
+      expect(updated?.targetType).toBe('paper');
+    });
+
+    it('returns null when the id does not exist', async () => {
+      expect(await targetImageRepository.update(4242, { targetType: 'steel' })).toBeNull();
+    });
+  });
+
+  describe('delete / count / countByDopeLog', () => {
+    it('removes an image and keeps the counts consistent', async () => {
+      const created = await targetImageRepository.create(validTargetImage({ dopeLogId }));
+      await targetImageRepository.create(validTargetImage({ dopeLogId }));
+
+      expect(await targetImageRepository.countByDopeLog(dopeLogId)).toBe(2);
+      expect(await targetImageRepository.delete(created.id as number)).toBe(true);
+      expect(await targetImageRepository.countByDopeLog(dopeLogId)).toBe(1);
+      expect(await targetImageRepository.count()).toBe(1);
+    });
+
+    it('reports failure when deleting an id that does not exist', async () => {
+      expect(await targetImageRepository.delete(4242)).toBe(false);
+    });
+  });
+
+  describe('getAll', () => {
+    it('returns an empty array when there are no images', async () => {
+      expect(await targetImageRepository.getAll()).toEqual([]);
+    });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -59,32 +59,37 @@ module.exports = {
   // which nothing came close to -- the gate was fiction, so it could not be run in CI and
   // caught nothing.
   //
-  // Ratcheted by #28 phase 2 (services layer). Measured after adding the repository suites:
+  // Ratcheted by #28 phase 2 as the services suites landed:
   //
-  //   metric       phase 1    now      floor
-  //   lines        16.71%     20.12%   19
-  //   statements   14.18%     17.13%   16
-  //   branches     11.09%     13.14%   12
-  //   functions    10.77%     13.96%   13
+  //   metric       phase 1   3 repos   all 7 repos   floor
+  //   lines        16.71%    20.12%    24.25%        23
+  //   statements   14.18%    17.13%    20.79%        20
+  //   branches     11.09%    13.14%    15.37%        14
+  //   functions    10.77%    13.96%    19.09%        18
+  //
+  // Measure with a clean `coverage/` directory (`rm -rf coverage` first). A stale one left
+  // behind by a `--selectProjects` run reports a lower figure, which would set the floors
+  // too loose and let real regressions through.
   //
   // Rule for each floor (unchanged from phase 1): the integer below actual, dropped one
   // further when that would leave under ~0.5pp of headroom -- which is all four here. Every
   // floor keeps >= 0.9pp of slack so landing a feature slightly ahead of its tests does not
   // break the build, while a real regression does.
   //
-  // ONLY EVER RAISE THESE. Services work is not finished: 4 of 7 repositories, plus
-  // MigrationRunner, ExportService and ImportService, are still largely uncovered, so the
-  // remainder of phase 2 should raise these again.
+  // ONLY EVER RAISE THESE. All 7 repositories are now at 98-100% statements, putting
+  // src/services/database/ at ~75%, but the wider services layer is not done:
+  // DatabaseService (21%), MigrationRunner (0%), ExportService and ImportService (0%)
+  // remain, and each should raise these floors again.
   //
   // Note the percentages are not comparable to pre-#35 figures (18.8%/19.01%): the `unit`
   // and `components` projects instrument differently and report different denominators for
   // the same source, so the baseline was re-measured once both were wired up.
   coverageThreshold: {
     global: {
-      branches: 12,
-      functions: 13,
-      lines: 19,
-      statements: 16,
+      branches: 14,
+      functions: 18,
+      lines: 23,
+      statements: 20,
     },
   },
 };

--- a/src/models/RangeSession.ts
+++ b/src/models/RangeSession.ts
@@ -108,7 +108,11 @@ export class RangeSession {
       endTime: row.end_time,
       distance: row.distance,
       shotCount: row.shot_count,
-      coldBoreShot: row.cold_bore_shot,
+      // SQLite has no boolean type, so this column is 0/1. Coerce it rather than passing
+      // the integer through: the field is typed `boolean`, and `toJSON()` emits it
+      // verbatim, so without this an exported session loaded from the database carries
+      // `1` while a freshly created one carries `true`.
+      coldBoreShot: Boolean(row.cold_bore_shot),
       notes: row.notes,
       createdAt: row.created_at,
     });


### PR DESCRIPTION
Issue #28 **phase 2, second part**. Completes the repository layer using the `node:sqlite`
harness from #37.

**`npm test`: 26 suites / 576 tests → 30 suites / 662 tests** (+86).

## All seven repositories are now covered

| repository | statements | branches | functions | lines |
| --- | --- | --- | --- | --- |
| `RifleProfileRepository` | 100% | 100% | 100% | 100% |
| `AmmoProfileRepository` | 100% | 95% | 100% | 100% |
| `DOPELogRepository` | 100% | 96% | 100% | 100% |
| **`EnvironmentRepository`** | **100%** | **100%** | **100%** | **100%** |
| **`ShotStringRepository`** | **100%** | 86% | **100%** | **100%** |
| **`RangeSessionRepository`** | **98.5%** | 93% | 96% | **100%** |
| **`TargetImageRepository`** | **98.4%** | 90% | 95% | **100%** |

`src/services/database/` is at **74.6% statements / 76.5% lines** — past the ~70% this phase
asked for on the repository layer.

## The tests found two real defects

That was the point of covering this layer, so I want to be explicit about both.

### 1. Fixed — `coldBoreShot` was not a boolean

`RangeSession.fromRow` assigned the raw SQLite integer to a field declared `boolean`:

```ts
coldBoreShot: row.cold_bore_shot,   // 1 | 0, but the type says boolean
```

SQLite has no boolean type, so a session **loaded from the database** carried `1`/`0` while a
**freshly constructed** one carried `true`/`false`. Every current consumer happens to use a
truthy check (`? :`, `&&`), so nothing visibly broke — but `toJSON()` emits the field
verbatim, so **exported JSON was inconsistent depending on where the session came from**.

That bears directly on the Export/Import round-trip work still outstanding in this phase, so
I fixed it (one-line coercion, with a comment explaining why). All 662 tests pass.

### 2. Not fixed, flagged for a decision — `create` discards a supplied timestamp

`EnvironmentRepository.create` omits `timestamp` from its INSERT column list:

```sql
INSERT INTO environment_snapshots (
  temperature, humidity, pressure, altitude, density_altitude,
  wind_speed, wind_direction, latitude, longitude
) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
```

So the schema's `DEFAULT (datetime('now'))` always wins and a caller-supplied timestamp is
silently discarded — even though `EnvironmentSnapshotData` declares `timestamp?: string`.
**Restoring a backup would lose original capture times.**

I left the behaviour alone: whether `create()` should honour a caller timestamp is a design
decision, not an obvious fix, and changing it silently could surprise callers. The tests set
timestamps with SQL (via a documented `createAged` helper) and record the behaviour where it
matters. Happy to fix it if you want it honoured.

Also noted for future suites: `EnvironmentSnapshot` **derives** `densityAltitude` when it
isn't supplied, so that column is never NULL — my first draft asserted otherwise and was
wrong.

## Coverage ratcheted

| metric | phase 1 | 3 repos | all 7 | floor |
| --- | --- | --- | --- | --- |
| lines | 16.71% | 20.12% | **24.25%** | 23 |
| statements | 14.18% | 17.13% | **20.79%** | 20 |
| branches | 11.09% | 13.14% | **15.37%** | 14 |
| functions | 10.77% | 13.96% | **19.09%** | 18 |

> [!WARNING]
> **Measurement gotcha, now recorded in `jest.config.js`:** measure with a clean `coverage/`
> directory. A stale one left behind by a `--selectProjects` run reports lower figures — it
> briefly had me set these floors ~1.5pp too loose before I caught it.

## Verification

- `npm test` exits 0 — 30 suites, 662 passed / 1 skipped
- `npm run test:coverage` exits 0 at the new floors
- **Each of the four floors was negative-tested individually** by raising it 3pp; every one
  fails with the correct actual value and exits 1. (My first attempt at this used a broken
  `sed` pattern that silently didn't substitute, so all four "passed" meaninglessly — worth
  knowing if you re-run it.)
- `npm run check` and `npm run type-check` exit 0

## Still outstanding in phase 2

- `DatabaseService` — 21%; `transaction`, `dropAllTables`, `checkIntegrity`, `getStatistics`,
  `reset` untouched
- `MigrationRunner` + the four migrations — 0%; worth asserting they apply in order and are
  idempotent
- `ExportService` / `ImportService` — 0%, and the issue specifically wants round-trip tests.
  Finding #1 above is a good argument for doing those next.
