### PR TITLE
test(services): add export/import round-trip tests; fix silent ammo data loss

### DIFF
--- a/__tests__/helpers/mockFileSystem.ts
+++ b/__tests__/helpers/mockFileSystem.ts
@@ -1,0 +1,56 @@
+/**
+ * In-memory stand-in for `expo-file-system`'s `File`/`Paths` API.
+ *
+ * ExportService writes with `new File(Paths.document, name).write(json)` and hands the
+ * resulting `uri` to expo-sharing. Tests need to read that content back to assert what was
+ * exported -- and, for round-trip tests, to feed it to ImportService. This keeps every write
+ * in a Map keyed by uri.
+ *
+ * Register with `jest.mock('expo-file-system', () => require('../../helpers/mockFileSystem'))`.
+ */
+
+const writes = new Map<string, string>();
+const order: string[] = [];
+
+export const Paths = {
+  document: 'file:///test-documents',
+  cache: 'file:///test-cache',
+};
+
+export class File {
+  readonly uri: string;
+
+  constructor(directory: string, filename: string) {
+    this.uri = `${directory}/${filename}`;
+  }
+
+  async write(contents: string): Promise<void> {
+    if (!writes.has(this.uri)) order.push(this.uri);
+    writes.set(this.uri, contents);
+  }
+
+  async text(): Promise<string> {
+    const contents = writes.get(this.uri);
+    if (contents === undefined) throw new Error(`No such file: ${this.uri}`);
+    return contents;
+  }
+
+  get exists(): boolean {
+    return writes.has(this.uri);
+  }
+}
+
+/** Contents written to `uri`, or undefined if nothing was written there. */
+export const readWritten = (uri: string): string | undefined => writes.get(uri);
+
+/** Uri of the most recently created file, for tests that do not capture it directly. */
+export const lastWrittenUri = (): string | undefined => order[order.length - 1];
+
+/** Every uri written, in creation order. */
+export const writtenUris = (): string[] => [...order];
+
+/** Clear all recorded writes. Call from `beforeEach`. */
+export const resetFileSystem = (): void => {
+  writes.clear();
+  order.length = 0;
+};

--- a/__tests__/unit/services/ExportImportRoundTrip.test.ts
+++ b/__tests__/unit/services/ExportImportRoundTrip.test.ts
@@ -1,0 +1,292 @@
+import * as Sharing from 'expo-sharing';
+
+import ammoProfileRepository from '../../../src/services/database/AmmoProfileRepository';
+import dopeLogRepository from '../../../src/services/database/DOPELogRepository';
+import environmentRepository from '../../../src/services/database/EnvironmentRepository';
+import rifleProfileRepository from '../../../src/services/database/RifleProfileRepository';
+import { exportFullBackup } from '../../../src/services/ExportService';
+import { importFullBackup } from '../../../src/services/ImportService';
+import { validAmmo, validDopeLog, validEnvironment, validRifle } from '../../helpers/fixtures';
+import { readWritten, resetFileSystem } from '../../helpers/mockFileSystem';
+import { installTestDatabase, uninstallTestDatabase } from '../../helpers/testDatabase';
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: () => require('../../helpers/testDatabase').openDatabaseAsync(),
+}));
+jest.mock('expo-file-system', () => require('../../helpers/mockFileSystem'));
+jest.mock('expo-sharing', () => ({
+  isAvailableAsync: jest.fn(async () => true),
+  shareAsync: jest.fn(async () => undefined),
+}));
+jest.mock('expo-document-picker', () => ({ getDocumentAsync: jest.fn() }));
+// expo-print ships ESM, which the ts-jest/node `unit` project cannot parse. ExportService
+// imports it at module scope for the PDF exporters, so it has to be mocked even though the
+// tests here only exercise the JSON path.
+jest.mock('expo-print', () => ({
+  printToFileAsync: jest.fn(async () => ({ uri: 'file:///test-cache/print.pdf' })),
+}));
+
+/**
+ * Shape of the file `exportFullBackup` writes. `@total-typescript/ts-reset` narrows
+ * `JSON.parse` to `unknown`, so parsed backups need an explicit cast.
+ */
+interface BackupFile {
+  exportDate: string;
+  exportVersion: string;
+  type: string;
+  data: { rifles: unknown[]; ammos: unknown[]; logs: unknown[] };
+  counts: { rifles: number; ammos: number; logs: number };
+}
+
+const parseBackup = (raw: string): BackupFile => JSON.parse(raw) as BackupFile;
+
+/** Points ImportService's picker + fetch at a uri already in the mock file system. */
+const stageImportFile = async (uri: string): Promise<void> => {
+  const DocumentPicker = await import('expo-document-picker');
+  (DocumentPicker.getDocumentAsync as jest.Mock).mockResolvedValue({
+    canceled: false,
+    assets: [{ uri }],
+  });
+  global.fetch = jest.fn(async () => ({
+    text: async () => readWritten(uri) as string,
+  })) as unknown as typeof fetch;
+};
+
+/** Everything currently in the database, for before/after comparison. */
+const snapshotDatabase = async () => ({
+  rifles: (await rifleProfileRepository.getAll()).map((r) => r.name),
+  ammos: (await ammoProfileRepository.getAll()).map((a) => a.name),
+  logs: (await dopeLogRepository.getAll()).map((l) => l.distance),
+});
+
+describe('Export/Import round trip', () => {
+  beforeEach(async () => {
+    await installTestDatabase();
+    resetFileSystem();
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await uninstallTestDatabase();
+  });
+
+  /** Seeds one rifle, one ammo, one environment and two DOPE logs. */
+  const seed = async () => {
+    const rifleId = (await rifleProfileRepository.create(validRifle({ name: 'Tikka T3x' })))
+      .id as number;
+    const ammoId = (await ammoProfileRepository.create(validAmmo({ name: '175gr SMK' })))
+      .id as number;
+    const environmentId = (await environmentRepository.create(validEnvironment())).id as number;
+    const ids = { rifleId, ammoId, environmentId };
+    await dopeLogRepository.create(validDopeLog(ids, { distance: 500 }));
+    await dopeLogRepository.create(validDopeLog(ids, { distance: 800 }));
+    return ids;
+  };
+
+  describe('exportFullBackup', () => {
+    it('writes a backup file and reports its uri', async () => {
+      await seed();
+
+      const result = await exportFullBackup(
+        await rifleProfileRepository.getAll(),
+        await ammoProfileRepository.getAll(),
+        await dopeLogRepository.getAll()
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.uri).toMatch(/mobiledope_backup_\d+\.json$/);
+      expect(readWritten(result.uri as string)).toBeDefined();
+    });
+
+    it('records counts that match the payload', async () => {
+      await seed();
+
+      const result = await exportFullBackup(
+        await rifleProfileRepository.getAll(),
+        await ammoProfileRepository.getAll(),
+        await dopeLogRepository.getAll()
+      );
+
+      const backup = parseBackup(readWritten(result.uri as string) as string);
+      expect(backup.type).toBe('full_backup');
+      expect(backup.exportVersion).toBe('1.0');
+      expect(backup.counts).toEqual({ rifles: 1, ammos: 1, logs: 2 });
+      expect(backup.data.rifles).toHaveLength(1);
+      expect(backup.data.ammos).toHaveLength(1);
+      expect(backup.data.logs).toHaveLength(2);
+    });
+
+    it('offers the file to the share sheet when sharing is available', async () => {
+      await seed();
+
+      const result = await exportFullBackup(
+        await rifleProfileRepository.getAll(),
+        await ammoProfileRepository.getAll(),
+        await dopeLogRepository.getAll()
+      );
+
+      expect(Sharing.shareAsync).toHaveBeenCalledWith(
+        result.uri,
+        expect.objectContaining({ mimeType: 'application/json' })
+      );
+    });
+
+    it('still succeeds when sharing is unavailable', async () => {
+      (Sharing.isAvailableAsync as jest.Mock).mockResolvedValueOnce(false);
+      await seed();
+
+      const result = await exportFullBackup([], [], []);
+
+      expect(result.success).toBe(true);
+      expect(Sharing.shareAsync).not.toHaveBeenCalled();
+    });
+
+    it('exports an empty backup without error', async () => {
+      const result = await exportFullBackup([], [], []);
+
+      const backup = parseBackup(readWritten(result.uri as string) as string);
+      expect(backup.counts).toEqual({ rifles: 0, ammos: 0, logs: 0 });
+    });
+
+    it('serialises coldBoreShot-style booleans consistently (regression for #38)', async () => {
+      await seed();
+
+      const result = await exportFullBackup(
+        await rifleProfileRepository.getAll(),
+        await ammoProfileRepository.getAll(),
+        await dopeLogRepository.getAll()
+      );
+
+      // Every exported value must be JSON-native: no 1/0 standing in for a boolean field.
+      const raw = readWritten(result.uri as string) as string;
+      expect(() => JSON.parse(raw)).not.toThrow();
+      expect(raw).not.toMatch(/"coldBoreShot":\s*[01]\b/);
+    });
+  });
+
+  describe('importFullBackup', () => {
+    it('restores rifles and ammo into an empty database', async () => {
+      await seed();
+      const before = await snapshotDatabase();
+      const exported = await exportFullBackup(
+        await rifleProfileRepository.getAll(),
+        await ammoProfileRepository.getAll(),
+        await dopeLogRepository.getAll()
+      );
+
+      // Fresh database, same backup file.
+      await installTestDatabase();
+      expect(await snapshotDatabase()).toEqual({ rifles: [], ammos: [], logs: [] });
+
+      await stageImportFile(exported.uri as string);
+      const result = await importFullBackup();
+
+      expect(result.success).toBe(true);
+
+      const after = await snapshotDatabase();
+      expect(after.rifles).toEqual(before.rifles);
+      expect(after.ammos).toEqual(before.ammos);
+    });
+
+    it('does not re-use the ids from the backup file', async () => {
+      await seed();
+      const exported = await exportFullBackup(
+        await rifleProfileRepository.getAll(),
+        await ammoProfileRepository.getAll(),
+        await dopeLogRepository.getAll()
+      );
+
+      // Import into a database that already holds a rifle, so ids cannot line up.
+      await installTestDatabase();
+      await rifleProfileRepository.create(validRifle({ name: 'Pre-existing' }));
+
+      await stageImportFile(exported.uri as string);
+      await importFullBackup();
+
+      const names = (await rifleProfileRepository.getAll()).map((r) => r.name);
+      expect(names).toContain('Pre-existing');
+      expect(names).toContain('Tikka T3x');
+    });
+
+    it('rejects a file that is not a full backup', async () => {
+      const uri = `${'file:///test-documents'}/partial.json`;
+      const { File } = await import('expo-file-system');
+      await new File('file:///test-documents', 'partial.json').write(
+        JSON.stringify({ exportVersion: '1.0', type: 'rifle_profiles', data: { rifles: [] } })
+      );
+
+      await stageImportFile(uri);
+      const result = await importFullBackup();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Not a full backup/);
+    });
+
+    it('rejects a structurally invalid file', async () => {
+      const { File } = await import('expo-file-system');
+      await new File('file:///test-documents', 'garbage.json').write(
+        JSON.stringify({ nope: true })
+      );
+
+      await stageImportFile('file:///test-documents/garbage.json');
+      const result = await importFullBackup();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Invalid backup file format/);
+    });
+
+    it('rejects a payload carrying a prototype-pollution key', async () => {
+      const { File } = await import('expo-file-system');
+      // Built as text so the key survives into the parsed object.
+      await new File('file:///test-documents', 'polluted.json').write(
+        '{"exportVersion":"1.0","type":"full_backup","__proto__":{"polluted":true},"data":{"rifles":[]}}'
+      );
+
+      await stageImportFile('file:///test-documents/polluted.json');
+      const result = await importFullBackup();
+
+      expect(result.success).toBe(false);
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    /**
+     * Documents issue #39. These assertions describe behaviour that is WRONG: a full backup
+     * cannot restore DOPE logs, because environments are never exported and foreign keys are
+     * not remapped when parents are re-keyed on import. They are here so the defect is
+     * visible and measured rather than invisible; when #39 is fixed these will fail and
+     * should be rewritten to assert that logs come back.
+     */
+    it('KNOWN DEFECT (#39): silently restores no DOPE logs', async () => {
+      await seed();
+      const exported = await exportFullBackup(
+        await rifleProfileRepository.getAll(),
+        await ammoProfileRepository.getAll(),
+        await dopeLogRepository.getAll()
+      );
+
+      const backup = parseBackup(readWritten(exported.uri as string) as string);
+      // Cause 1: environments are absent from the payload entirely.
+      expect(backup.data).not.toHaveProperty('environments');
+      expect(backup.counts).not.toHaveProperty('environments');
+
+      await installTestDatabase();
+      await stageImportFile(exported.uri as string);
+      const result = await importFullBackup();
+
+      // Cause 2: each log still references the original rifle/ammo/environment ids, so the
+      // insert violates the foreign key -- and the per-record catch hides it.
+      expect(result.success).toBe(true);
+      expect(await dopeLogRepository.count()).toBe(0);
+    });
+
+    it('reports cancellation rather than throwing', async () => {
+      const DocumentPicker = await import('expo-document-picker');
+      (DocumentPicker.getDocumentAsync as jest.Mock).mockResolvedValue({ canceled: true });
+
+      const result = await importFullBackup();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/cancelled/i);
+    });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -61,11 +61,11 @@ module.exports = {
   //
   // Ratcheted by #28 phase 2 as the services suites landed:
   //
-  //   metric       phase 1   3 repos   all 7 repos   floor
-  //   lines        16.71%    20.12%    24.25%        23
-  //   statements   14.18%    17.13%    20.79%        20
-  //   branches     11.09%    13.14%    15.37%        14
-  //   functions    10.77%    13.96%    19.09%        18
+  //   metric       phase 1   3 repos   all 7 repos   + export/import   floor
+  //   lines        16.71%    20.12%    24.25%        27.00%            26
+  //   statements   14.18%    17.13%    20.79%        23.47%            22
+  //   branches     11.09%    13.14%    15.37%        16.68%            16
+  //   functions    10.77%    13.96%    19.09%        20.93%            20
   //
   // Measure with a clean `coverage/` directory (`rm -rf coverage` first). A stale one left
   // behind by a `--selectProjects` run reports a lower figure, which would set the floors
@@ -76,20 +76,20 @@ module.exports = {
   // floor keeps >= 0.9pp of slack so landing a feature slightly ahead of its tests does not
   // break the build, while a real regression does.
   //
-  // ONLY EVER RAISE THESE. All 7 repositories are now at 98-100% statements, putting
-  // src/services/database/ at ~75%, but the wider services layer is not done:
-  // DatabaseService (21%), MigrationRunner (0%), ExportService and ImportService (0%)
-  // remain, and each should raise these floors again.
+  // ONLY EVER RAISE THESE. All 7 repositories sit at 98-100% statements and ImportService
+  // is at ~59%, but the layer is not done: ExportService is still ~9% (only the JSON
+  // full-backup path is covered; the CSV, Markdown and PDF exporters are not),
+  // DatabaseService is 21%, and MigrationRunner is 0%.
   //
   // Note the percentages are not comparable to pre-#35 figures (18.8%/19.01%): the `unit`
   // and `components` projects instrument differently and report different denominators for
   // the same source, so the baseline was re-measured once both were wired up.
   coverageThreshold: {
     global: {
-      branches: 14,
-      functions: 18,
-      lines: 23,
-      statements: 20,
+      branches: 16,
+      functions: 20,
+      lines: 26,
+      statements: 22,
     },
   },
 };

--- a/src/services/ImportService.ts
+++ b/src/services/ImportService.ts
@@ -88,6 +88,11 @@ const RIFLE_ALLOWED_FIELDS = [
 const AMMO_ALLOWED_FIELDS = [
   'name',
   'manufacturer',
+  // `caliber` is required by AmmoProfile's validate() and is how ammo is matched to rifles
+  // (see ADR-004). Omitting it here meant every ammo profile in a backup failed to
+  // construct on import, and the per-record try/catch swallowed the error -- so restoring a
+  // backup silently produced zero ammo profiles while still reporting success.
+  'caliber',
   'bulletWeight',
   'bulletType',
   'ballisticCoefficientG1',


### PR DESCRIPTION
Issue #28 **phase 2, third part** — the round-trip tests the issue asked for.

**`npm test`: 30 suites / 662 tests → 31 suites / 675 tests.**

> [!CAUTION]
> **These tests found two data-loss bugs in backup/restore.** One is fixed here; the other
> needs a format change and is filed as #39.

## The round trip is real, not mocked

`__tests__/helpers/mockFileSystem.ts` is an in-memory stand-in for expo-file-system's
`File`/`Paths` that records every write by uri, so a test can read back exactly what was
exported and hand it to the importer.

Everything else is genuine: seed via the repositories against the `node:sqlite` harness →
`exportFullBackup` → **fresh database** → `importFullBackup` through the actual Zustand stores
→ assert what came back.

(`expo-sharing`, `expo-document-picker` and `expo-print` are mocked. `expo-print` ships ESM
that the ts-jest `unit` project can't parse, and `ExportService` imports it at module scope
for the PDF exporters — so it has to be mocked even though these tests only touch the JSON
path.)

## Bug 1 — fixed: restoring a backup silently lost **all** ammunition

`AMMO_ALLOWED_FIELDS` omitted `'caliber'`. So `pickAllowedFields` stripped it from every ammo
record, `new AmmoProfile(...)` threw, and the per-record `try/catch` swallowed it:

```
Failed to import ammo: Error: Caliber is required
    at AmmoProfile.validate (src/models/AmmoProfile.ts:66:13)
    at importFullBackup (src/services/ImportService.ts:250:27)
```

**Restoring a full backup produced zero ammunition profiles while reporting success.** Caliber
is required by `validate()` and is how ammo is matched to rifles (ADR-004);
`RIFLE_ALLOWED_FIELDS` already included it, so this was a plain oversight. One-line fix.

## Bug 2 — filed as #39, deliberately not fixed here: DOPE logs cannot be restored

Two compounding causes:

1. **`exportFullBackup` never exports environment snapshots.** `dope_logs.environment_id` is
   `NOT NULL` with an FK, so after a restore there is nothing for a log to point at.
2. **FKs are exported as raw ids but parents are re-keyed on import.**
   `DOPE_LOG_ALLOWED_FIELDS` keeps `rifleId`/`ammoId`/`environmentId` verbatim while `id` is
   stripped from rifles and ammo (correct, mass-assignment hardening) so they get new
   `AUTOINCREMENT` ids.

```
Failed to import DOPE log: Error: FOREIGN KEY constraint failed
    at DOPELogRepository.create (src/services/database/DOPELogRepository.ts:13:29)
    at importFullBackup (src/services/ImportService.ts:271)
```

`importFullBackup` returns `success: true` with `logsImported: 0`. **A user who reinstalls and
restores gets rifles and ammo back and loses their entire engagement history, with no error
shown.**

Fixing it means changing the backup format — export environments, remap old→new ids, bump
`exportVersion` — which is a design decision, not a patch. Hence #39 rather than an
improvised fix inside a testing PR.

**A test documents it** (`KNOWN DEFECT (#39)`) and asserts the current *wrong* behaviour, so
it is measured rather than invisible. When #39 is fixed that test will fail and should be
rewritten to assert logs come back.

## Also covered

Export payload shape and counts · share-sheet invocation · the sharing-unavailable branch ·
empty-backup export · rejection of non-full-backup files · structurally invalid files ·
prototype-pollution keys · picker cancellation.

## Coverage

| metric | all 7 repos | + export/import | floor |
| --- | --- | --- | --- |
| lines | 24.25% | **27.00%** | 26 |
| statements | 20.79% | **23.47%** | 22 |
| branches | 15.37% | **16.68%** | 16 |
| functions | 19.09% | **20.93%** | 20 |

`ImportService` is now at **58.7% statements**. `ExportService` is only at **~9%** — this
covers the JSON full-backup path, not the CSV, Markdown or PDF exporters, which are most of
its 1452 lines.

## Verification

- `npm test` exits 0 — 31 suites, 675 passed / 1 skipped
- `npm run test:coverage` exits 0; all four floors negative-tested individually (each raised
  3pp → exit 1)
- `npm run check` and `npm run type-check` exit 0

## Still outstanding in phase 2

ExportService's CSV/Markdown/PDF paths · `DatabaseService` (21%) · `MigrationRunner` and the
four migrations (0%).
