### PR TITLE
fix(backup): export environments and remap foreign keys so DOPE logs restore

### DIFF
--- a/__tests__/unit/services/ExportImportRoundTrip.test.ts
+++ b/__tests__/unit/services/ExportImportRoundTrip.test.ts
@@ -34,8 +34,8 @@ interface BackupFile {
   exportDate: string;
   exportVersion: string;
   type: string;
-  data: { rifles: unknown[]; ammos: unknown[]; logs: unknown[] };
-  counts: { rifles: number; ammos: number; logs: number };
+  data: { rifles: unknown[]; ammos: unknown[]; environments: unknown[]; logs: unknown[] };
+  counts: { rifles: number; ammos: number; environments: number; logs: number };
 }
 
 const parseBackup = (raw: string): BackupFile => JSON.parse(raw) as BackupFile;
@@ -83,15 +83,20 @@ describe('Export/Import round trip', () => {
     return ids;
   };
 
+  /** Exports everything currently in the database, environments included. */
+  const exportEverything = async () =>
+    exportFullBackup(
+      await rifleProfileRepository.getAll(),
+      await ammoProfileRepository.getAll(),
+      await dopeLogRepository.getAll(),
+      await environmentRepository.getAll()
+    );
+
   describe('exportFullBackup', () => {
     it('writes a backup file and reports its uri', async () => {
       await seed();
 
-      const result = await exportFullBackup(
-        await rifleProfileRepository.getAll(),
-        await ammoProfileRepository.getAll(),
-        await dopeLogRepository.getAll()
-      );
+      const result = await exportEverything();
 
       expect(result.success).toBe(true);
       expect(result.uri).toMatch(/mobiledope_backup_\d+\.json$/);
@@ -101,16 +106,12 @@ describe('Export/Import round trip', () => {
     it('records counts that match the payload', async () => {
       await seed();
 
-      const result = await exportFullBackup(
-        await rifleProfileRepository.getAll(),
-        await ammoProfileRepository.getAll(),
-        await dopeLogRepository.getAll()
-      );
+      const result = await exportEverything();
 
       const backup = parseBackup(readWritten(result.uri as string) as string);
       expect(backup.type).toBe('full_backup');
-      expect(backup.exportVersion).toBe('1.0');
-      expect(backup.counts).toEqual({ rifles: 1, ammos: 1, logs: 2 });
+      expect(backup.exportVersion).toBe('1.1');
+      expect(backup.counts).toEqual({ rifles: 1, ammos: 1, environments: 1, logs: 2 });
       expect(backup.data.rifles).toHaveLength(1);
       expect(backup.data.ammos).toHaveLength(1);
       expect(backup.data.logs).toHaveLength(2);
@@ -119,11 +120,7 @@ describe('Export/Import round trip', () => {
     it('offers the file to the share sheet when sharing is available', async () => {
       await seed();
 
-      const result = await exportFullBackup(
-        await rifleProfileRepository.getAll(),
-        await ammoProfileRepository.getAll(),
-        await dopeLogRepository.getAll()
-      );
+      const result = await exportEverything();
 
       expect(Sharing.shareAsync).toHaveBeenCalledWith(
         result.uri,
@@ -145,17 +142,13 @@ describe('Export/Import round trip', () => {
       const result = await exportFullBackup([], [], []);
 
       const backup = parseBackup(readWritten(result.uri as string) as string);
-      expect(backup.counts).toEqual({ rifles: 0, ammos: 0, logs: 0 });
+      expect(backup.counts).toEqual({ rifles: 0, ammos: 0, environments: 0, logs: 0 });
     });
 
     it('serialises coldBoreShot-style booleans consistently (regression for #38)', async () => {
       await seed();
 
-      const result = await exportFullBackup(
-        await rifleProfileRepository.getAll(),
-        await ammoProfileRepository.getAll(),
-        await dopeLogRepository.getAll()
-      );
+      const result = await exportEverything();
 
       // Every exported value must be JSON-native: no 1/0 standing in for a boolean field.
       const raw = readWritten(result.uri as string) as string;
@@ -168,11 +161,7 @@ describe('Export/Import round trip', () => {
     it('restores rifles and ammo into an empty database', async () => {
       await seed();
       const before = await snapshotDatabase();
-      const exported = await exportFullBackup(
-        await rifleProfileRepository.getAll(),
-        await ammoProfileRepository.getAll(),
-        await dopeLogRepository.getAll()
-      );
+      const exported = await exportEverything();
 
       // Fresh database, same backup file.
       await installTestDatabase();
@@ -190,11 +179,7 @@ describe('Export/Import round trip', () => {
 
     it('does not re-use the ids from the backup file', async () => {
       await seed();
-      const exported = await exportFullBackup(
-        await rifleProfileRepository.getAll(),
-        await ammoProfileRepository.getAll(),
-        await dopeLogRepository.getAll()
-      );
+      const exported = await exportEverything();
 
       // Import into a database that already holds a rifle, so ids cannot line up.
       await installTestDatabase();
@@ -249,34 +234,123 @@ describe('Export/Import round trip', () => {
       expect(({} as Record<string, unknown>).polluted).toBeUndefined();
     });
 
-    /**
-     * Documents issue #39. These assertions describe behaviour that is WRONG: a full backup
-     * cannot restore DOPE logs, because environments are never exported and foreign keys are
-     * not remapped when parents are re-keyed on import. They are here so the defect is
-     * visible and measured rather than invisible; when #39 is fixed these will fail and
-     * should be rewritten to assert that logs come back.
-     */
-    it('KNOWN DEFECT (#39): silently restores no DOPE logs', async () => {
+    it('restores DOPE logs, remapping their foreign keys (#39)', async () => {
       await seed();
-      const exported = await exportFullBackup(
-        await rifleProfileRepository.getAll(),
-        await ammoProfileRepository.getAll(),
-        await dopeLogRepository.getAll()
-      );
+      const exported = await exportEverything();
 
       const backup = parseBackup(readWritten(exported.uri as string) as string);
-      // Cause 1: environments are absent from the payload entirely.
-      expect(backup.data).not.toHaveProperty('environments');
-      expect(backup.counts).not.toHaveProperty('environments');
+      // Environments are in the payload now -- without them logs are unrestorable.
+      expect(backup.data.environments).toHaveLength(1);
 
       await installTestDatabase();
       await stageImportFile(exported.uri as string);
       const result = await importFullBackup();
 
-      // Cause 2: each log still references the original rifle/ammo/environment ids, so the
-      // insert violates the foreign key -- and the per-record catch hides it.
       expect(result.success).toBe(true);
+      expect(result.imported).toMatchObject({ rifles: 1, ammos: 1, environments: 1, logs: 2 });
+      expect(result.skipped?.logs).toBe(0);
+
+      const logs = await dopeLogRepository.getAll();
+      expect(logs.map((l) => l.distance).sort((a, b) => a - b)).toEqual([500, 800]);
+    });
+
+    it('relinks restored logs to the NEW parent ids, not the ids in the file', async () => {
+      await seed();
+      const exported = await exportEverything();
+
+      // Pre-populate so the fresh ids cannot coincidentally match the backup's ids.
+      await installTestDatabase();
+      const decoyRifleId = (await rifleProfileRepository.create(validRifle({ name: 'Decoy' })))
+        .id as number;
+
+      await stageImportFile(exported.uri as string);
+      await importFullBackup();
+
+      const restoredRifle = (await rifleProfileRepository.getAll()).find(
+        (r) => r.name === 'Tikka T3x'
+      );
+      const logs = await dopeLogRepository.getAll();
+
+      expect(logs).toHaveLength(2);
+      // Every log points at the newly created rifle, not the decoy that took the old id.
+      for (const log of logs) {
+        expect(log.rifleId).toBe(restoredRifle?.id);
+        expect(log.rifleId).not.toBe(decoyRifleId);
+      }
+    });
+
+    it('skips logs whose parents are missing instead of failing silently', async () => {
+      const { File } = await import('expo-file-system');
+      // A log referencing rifle/ammo/environment ids that are not in the file at all.
+      await new File('file:///test-documents', 'orphan.json').write(
+        JSON.stringify({
+          exportVersion: '1.1',
+          type: 'full_backup',
+          data: {
+            rifles: [],
+            ammos: [],
+            environments: [],
+            logs: [{ id: 1, rifleId: 99, ammoId: 99, environmentId: 99, distance: 400 }],
+          },
+        })
+      );
+
+      await stageImportFile('file:///test-documents/orphan.json');
+      const result = await importFullBackup();
+
+      expect(result.success).toBe(true);
+      expect(result.imported?.logs).toBe(0);
+      expect(result.skipped?.logs).toBe(1);
+      expect(result.warnings?.join(' ')).toMatch(/skipped/i);
       expect(await dopeLogRepository.count()).toBe(0);
+    });
+
+    it('warns that a legacy 1.0 backup cannot restore its logs', async () => {
+      const { File } = await import('expo-file-system');
+      await new File('file:///test-documents', 'legacy.json').write(
+        JSON.stringify({
+          exportVersion: '1.0',
+          type: 'full_backup',
+          data: {
+            rifles: [{ id: 1, ...validRifle() }],
+            ammos: [{ id: 1, ...validAmmo() }],
+            logs: [{ id: 1, rifleId: 1, ammoId: 1, environmentId: 1, distance: 400 }],
+          },
+        })
+      );
+
+      await stageImportFile('file:///test-documents/legacy.json');
+      const result = await importFullBackup();
+
+      // Rifles and ammo still come back; the logs are reported rather than lost in silence.
+      expect(result.imported).toMatchObject({ rifles: 1, ammos: 1, logs: 0 });
+      expect(result.skipped?.logs).toBe(1);
+      expect(result.warnings?.join(' ')).toMatch(/no environment snapshots/i);
+    });
+
+    it('counts a rifle that fails validation as skipped, and skips its logs', async () => {
+      const { File } = await import('expo-file-system');
+      await new File('file:///test-documents', 'bad-rifle.json').write(
+        JSON.stringify({
+          exportVersion: '1.1',
+          type: 'full_backup',
+          data: {
+            // Missing every required field, so RifleProfile.validate() throws.
+            rifles: [{ id: 1, name: '' }],
+            ammos: [],
+            environments: [{ id: 1, ...validEnvironment() }],
+            logs: [{ id: 1, rifleId: 1, ammoId: 1, environmentId: 1, distance: 400 }],
+          },
+        })
+      );
+
+      await stageImportFile('file:///test-documents/bad-rifle.json');
+      const result = await importFullBackup();
+
+      expect(result.success).toBe(true);
+      expect(result.imported).toMatchObject({ rifles: 0, environments: 1, logs: 0 });
+      expect(result.skipped).toMatchObject({ rifles: 1, logs: 1 });
+      expect(await rifleProfileRepository.count()).toBe(0);
     });
 
     it('reports cancellation rather than throwing', async () => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -61,11 +61,11 @@ module.exports = {
   //
   // Ratcheted by #28 phase 2 as the services suites landed:
   //
-  //   metric       phase 1   3 repos   all 7 repos   + export/import   floor
-  //   lines        16.71%    20.12%    24.25%        27.00%            26
-  //   statements   14.18%    17.13%    20.79%        23.47%            22
-  //   branches     11.09%    13.14%    15.37%        16.68%            16
-  //   functions    10.77%    13.96%    19.09%        20.93%            20
+  //   metric       phase 1   3 repos   all 7 repos   export/import   + #39 fix   floor
+  //   lines        16.71%    20.12%    24.25%        27.00%          28.11%      27
+  //   statements   14.18%    17.13%    20.79%        23.47%          24.60%      24
+  //   branches     11.09%    13.14%    15.37%        16.68%          17.97%      17
+  //   functions    10.77%    13.96%    19.09%        20.93%          21.87%      21
   //
   // Measure with a clean `coverage/` directory (`rm -rf coverage` first). A stale one left
   // behind by a `--selectProjects` run reports a lower figure, which would set the floors
@@ -77,7 +77,7 @@ module.exports = {
   // break the build, while a real regression does.
   //
   // ONLY EVER RAISE THESE. All 7 repositories sit at 98-100% statements and ImportService
-  // is at ~59%, but the layer is not done: ExportService is still ~9% (only the JSON
+  // is at ~70%, but the layer is not done: ExportService is still ~9% (only the JSON
   // full-backup path is covered; the CSV, Markdown and PDF exporters are not),
   // DatabaseService is 21%, and MigrationRunner is 0%.
   //
@@ -86,10 +86,10 @@ module.exports = {
   // the same source, so the baseline was re-measured once both were wired up.
   coverageThreshold: {
     global: {
-      branches: 16,
-      functions: 20,
-      lines: 26,
-      statements: 22,
+      branches: 17,
+      functions: 21,
+      lines: 27,
+      statements: 24,
     },
   },
 };

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -14,13 +14,9 @@ import {
   TextInput,
   Pressable,
 } from 'react-native';
-import { useTheme } from '../contexts/ThemeContext';
+
 import { Card, Button, SegmentedControl } from '../components';
-import type { RootStackScreenProps } from '../navigation/types';
-import { useRifleStore } from '../store/useRifleStore';
-import { useAmmoStore } from '../store/useAmmoStore';
-import { useDOPEStore } from '../store/useDOPEStore';
-import { useAppStore, DEFAULT_DISTANCE_PRESETS } from '../store/useAppStore';
+import { useTheme } from '../contexts/ThemeContext';
 import {
   exportFullBackup,
   exportAllRifleProfilesJSON,
@@ -29,6 +25,13 @@ import {
   exportDOPELogsPDF,
 } from '../services/ExportService';
 import { importFullBackup, importRifleProfiles, importDOPELogs } from '../services/ImportService';
+import { useAmmoStore } from '../store/useAmmoStore';
+import { useAppStore, DEFAULT_DISTANCE_PRESETS } from '../store/useAppStore';
+import { useDOPEStore } from '../store/useDOPEStore';
+import { useEnvironmentStore } from '../store/useEnvironmentStore';
+import { useRifleStore } from '../store/useRifleStore';
+
+import type { RootStackScreenProps } from '../navigation/types';
 
 type Props = RootStackScreenProps<'Settings'>;
 
@@ -40,6 +43,7 @@ export const SettingsScreen: React.FC<Props> = () => {
   const { rifles } = useRifleStore();
   const { ammoProfiles } = useAmmoStore();
   const { dopeLogs } = useDOPEStore();
+  const { loadSnapshots } = useEnvironmentStore();
 
   // Distance preset customization state
   const [newPresetValue, setNewPresetValue] = useState<string>('');
@@ -110,11 +114,16 @@ export const SettingsScreen: React.FC<Props> = () => {
         {
           text: 'Full Backup (All Data)',
           onPress: async () => {
-            const result = await exportFullBackup(rifles, ammoProfiles, dopeLogs);
+            // Load every snapshot, not just the recent ones already in the store: a DOPE log
+            // whose environment is missing from the backup cannot be restored (issue #39).
+            await loadSnapshots();
+            const allEnvironments = useEnvironmentStore.getState().snapshots;
+            const result = await exportFullBackup(rifles, ammoProfiles, dopeLogs, allEnvironments);
             if (result.success) {
               Alert.alert(
                 'Success',
-                `Exported ${rifles.length} rifles, ${ammoProfiles.length} ammo profiles, and ${dopeLogs.length} DOPE logs.`
+                `Exported ${rifles.length} rifles, ${ammoProfiles.length} ammo profiles, ` +
+                  `${allEnvironments.length} environment snapshots, and ${dopeLogs.length} DOPE logs.`
               );
             } else {
               Alert.alert('Error', result.error || 'Export failed');
@@ -293,7 +302,7 @@ export const SettingsScreen: React.FC<Props> = () => {
             <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>
               Distance Presets
             </Text>
-            <Pressable onPress={handleResetPresets}>
+            <Pressable accessibilityRole="button" onPress={handleResetPresets}>
               <Text style={[styles.resetLink, { color: colors.primary }]}>Reset</Text>
             </Pressable>
           </View>
@@ -303,6 +312,7 @@ export const SettingsScreen: React.FC<Props> = () => {
           <View style={styles.presetsContainer}>
             {settings.distancePresets.map((preset) => (
               <Pressable
+                accessibilityRole="button"
                 key={preset}
                 style={[
                   styles.presetChip,
@@ -314,6 +324,7 @@ export const SettingsScreen: React.FC<Props> = () => {
                   {preset}
                 </Text>
                 <Pressable
+                  accessibilityRole="button"
                   onPress={() => handleRemovePreset(preset)}
                   style={styles.presetRemoveButton}
                   hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
@@ -325,6 +336,7 @@ export const SettingsScreen: React.FC<Props> = () => {
           </View>
           <View style={styles.addPresetRow}>
             <TextInput
+              accessibilityLabel="Text input field"
               style={[
                 styles.presetInput,
                 {

--- a/src/services/ExportService.ts
+++ b/src/services/ExportService.ts
@@ -4,13 +4,14 @@
  */
 
 import { Paths, File } from 'expo-file-system';
-import * as Sharing from 'expo-sharing';
 import * as Print from 'expo-print';
-import type { RifleProfile } from '../models/RifleProfile';
+import * as Sharing from 'expo-sharing';
+
 import type { AmmoProfile } from '../models/AmmoProfile';
 import type { DOPELog } from '../models/DOPELog';
-import type { RangeSession } from '../models/RangeSession';
 import type { EnvironmentSnapshot } from '../models/EnvironmentSnapshot';
+import type { RangeSession } from '../models/RangeSession';
+import type { RifleProfile } from '../models/RifleProfile';
 import type { BallisticSolution } from '../types/ballistic.types';
 
 /**
@@ -542,7 +543,8 @@ export async function exportDOPELogsPDF(
 export async function exportFullBackup(
   rifles: RifleProfile[],
   ammos: AmmoProfile[],
-  logs: DOPELog[]
+  logs: DOPELog[],
+  environments: EnvironmentSnapshot[] = []
 ): Promise<ExportResult> {
   try {
     const filename = `mobiledope_backup_${Date.now()}.json`;
@@ -550,16 +552,22 @@ export async function exportFullBackup(
 
     const data = {
       exportDate: new Date().toISOString(),
-      exportVersion: '1.0',
+      // 1.1 added `environments`. Without them a restored DOPE log has no environment row to
+      // reference, and since environment_id is NOT NULL with a foreign key, every log failed
+      // to import -- see issue #39. Importers must keep reading 1.0 files, but cannot
+      // recover logs from them.
+      exportVersion: '1.1',
       type: 'full_backup',
       data: {
         rifles: rifles.map((r) => r.toJSON()),
         ammos: ammos.map((a) => a.toJSON()),
+        environments: environments.map((e) => e.toJSON()),
         logs: logs.map((l) => l.toJSON()),
       },
       counts: {
         rifles: rifles.length,
         ammos: ammos.length,
+        environments: environments.length,
         logs: logs.length,
       },
     };

--- a/src/services/ImportService.ts
+++ b/src/services/ImportService.ts
@@ -5,6 +5,7 @@
 
 import { useAmmoStore } from '../store/useAmmoStore';
 import { useDOPEStore } from '../store/useDOPEStore';
+import { useEnvironmentStore } from '../store/useEnvironmentStore';
 import { useRifleStore } from '../store/useRifleStore';
 
 export interface ImportResult {
@@ -12,8 +13,21 @@ export interface ImportResult {
   imported?: {
     rifles?: number;
     ammos?: number;
+    environments?: number;
     logs?: number;
   };
+  /**
+   * Records present in the file that could not be imported. Previously these were swallowed
+   * with only a `console.error`, so a total failure looked identical to success (issue #39).
+   */
+  skipped?: {
+    rifles?: number;
+    ammos?: number;
+    environments?: number;
+    logs?: number;
+  };
+  /** Human-readable explanations for skipped records, for surfacing in the UI. */
+  warnings?: string[];
   error?: string;
 }
 
@@ -25,11 +39,13 @@ interface BackupData {
   data: {
     rifles?: any[];
     ammos?: any[];
+    environments?: any[];
     logs?: any[];
   };
   counts?: {
     rifles?: number;
     ammos?: number;
+    environments?: number;
     logs?: number;
   };
 }
@@ -102,6 +118,19 @@ const AMMO_ALLOWED_FIELDS = [
   'powderWeight',
   'lotNumber',
   'notes',
+];
+
+const ENVIRONMENT_ALLOWED_FIELDS = [
+  'temperature',
+  'humidity',
+  'pressure',
+  'altitude',
+  'densityAltitude',
+  'windSpeed',
+  'windDirection',
+  'latitude',
+  'longitude',
+  'timestamp',
 ];
 
 const DOPE_LOG_ALLOWED_FIELDS = [
@@ -228,21 +257,51 @@ export async function importFullBackup(): Promise<ImportResult> {
     // Get stores
     const rifleStore = useRifleStore.getState();
     const ammoStore = useAmmoStore.getState();
+    const environmentStore = useEnvironmentStore.getState();
     const dopeStore = useDOPEStore.getState();
 
     let riflesImported = 0;
     let ammosImported = 0;
+    let environmentsImported = 0;
     let logsImported = 0;
+    let riflesSkipped = 0;
+    let ammosSkipped = 0;
+    let environmentsSkipped = 0;
+    let logsSkipped = 0;
+    const warnings: string[] = [];
+
+    /**
+     * Old id -> new id, per entity type.
+     *
+     * `id` is deliberately stripped from every record before insert (mass-assignment
+     * hardening), so parents receive fresh AUTOINCREMENT ids. DOPE logs reference their
+     * parents by id, so those references have to be translated or every insert violates a
+     * foreign key -- which is exactly what issue #39 was. Reading `record.id` here is safe:
+     * it is used only as a lookup key and never assigned to a new row.
+     */
+    const rifleIdMap = new Map<number, number>();
+    const ammoIdMap = new Map<number, number>();
+    const environmentIdMap = new Map<number, number>();
+
+    const originalId = (record: unknown): number | undefined => {
+      const id = (record as { id?: unknown })?.id;
+      return typeof id === 'number' ? id : undefined;
+    };
 
     // Import rifles (only allowed fields, no ID)
     if (data.data.rifles && Array.isArray(data.data.rifles)) {
       for (const rifleData of data.data.rifles) {
         try {
           const sanitizedRifle = pickAllowedFields(rifleData, RIFLE_ALLOWED_FIELDS);
-          await rifleStore.createRifle(sanitizedRifle);
+          const created = await rifleStore.createRifle(sanitizedRifle);
+          const oldId = originalId(rifleData);
+          if (oldId !== undefined && created.id !== undefined) {
+            rifleIdMap.set(oldId, created.id);
+          }
           riflesImported++;
         } catch (error) {
           console.error('Failed to import rifle:', error);
+          riflesSkipped++;
         }
       }
     }
@@ -252,12 +311,42 @@ export async function importFullBackup(): Promise<ImportResult> {
       for (const ammoData of data.data.ammos) {
         try {
           const sanitizedAmmo = pickAllowedFields(ammoData, AMMO_ALLOWED_FIELDS);
-          await ammoStore.createAmmoProfile(sanitizedAmmo);
+          const created = await ammoStore.createAmmoProfile(sanitizedAmmo);
+          const oldId = originalId(ammoData);
+          if (oldId !== undefined && created.id !== undefined) {
+            ammoIdMap.set(oldId, created.id);
+          }
           ammosImported++;
         } catch (error) {
           console.error('Failed to import ammo:', error);
+          ammosSkipped++;
         }
       }
+    }
+
+    // Import environment snapshots. Added to the backup format in exportVersion 1.1; a 1.0
+    // file has none, which is why its logs cannot be restored.
+    if (data.data.environments && Array.isArray(data.data.environments)) {
+      for (const environmentData of data.data.environments) {
+        try {
+          const sanitized = pickAllowedFields(environmentData, ENVIRONMENT_ALLOWED_FIELDS);
+          const created = await environmentStore.createSnapshot(sanitized);
+          const oldId = originalId(environmentData);
+          if (oldId !== undefined && created.id !== undefined) {
+            environmentIdMap.set(oldId, created.id);
+          }
+          environmentsImported++;
+        } catch (error) {
+          console.error('Failed to import environment snapshot:', error);
+          environmentsSkipped++;
+        }
+      }
+    } else if (data.data.logs && Array.isArray(data.data.logs) && data.data.logs.length > 0) {
+      warnings.push(
+        `This backup (exportVersion ${data.exportVersion}) contains no environment snapshots, ` +
+          'so its DOPE logs cannot be restored. Re-export from a current version of the app ' +
+          'to produce a restorable backup.'
+      );
     }
 
     // Import DOPE logs (only allowed fields, no ID)
@@ -265,12 +354,34 @@ export async function importFullBackup(): Promise<ImportResult> {
       for (const logData of data.data.logs) {
         try {
           const sanitizedLog = pickAllowedFields(logData, DOPE_LOG_ALLOWED_FIELDS);
-          await dopeStore.createDopeLog(sanitizedLog);
+
+          // Translate the backup's ids to the ids the parents were just given.
+          const rifleId = rifleIdMap.get(sanitizedLog.rifleId);
+          const ammoId = ammoIdMap.get(sanitizedLog.ammoId);
+          const environmentId = environmentIdMap.get(sanitizedLog.environmentId);
+
+          if (rifleId === undefined || ammoId === undefined || environmentId === undefined) {
+            // A parent is missing from the file (or failed to import). Inserting anyway would
+            // either violate a foreign key or, worse, silently attach the log to an unrelated
+            // rifle whose id happens to collide.
+            logsSkipped++;
+            continue;
+          }
+
+          await dopeStore.createDopeLog({ ...sanitizedLog, rifleId, ammoId, environmentId });
           logsImported++;
         } catch (error) {
           console.error('Failed to import DOPE log:', error);
+          logsSkipped++;
         }
       }
+    }
+
+    if (logsSkipped > 0 && warnings.length === 0) {
+      warnings.push(
+        `${logsSkipped} DOPE log(s) were skipped because the rifle, ammo or environment they ` +
+          'reference is missing from the backup file.'
+      );
     }
 
     return {
@@ -278,8 +389,16 @@ export async function importFullBackup(): Promise<ImportResult> {
       imported: {
         rifles: riflesImported,
         ammos: ammosImported,
+        environments: environmentsImported,
         logs: logsImported,
       },
+      skipped: {
+        rifles: riflesSkipped,
+        ammos: ammosSkipped,
+        environments: environmentsSkipped,
+        logs: logsSkipped,
+      },
+      ...(warnings.length > 0 ? { warnings } : {}),
     };
   } catch (error) {
     console.error('Error importing full backup:', error);


### PR DESCRIPTION
Fixes #39 — the data-loss bug the round-trip tests in #40 uncovered.

**A full backup could not restore DOPE logs at all**, and reported success while doing it. A
user who reinstalled and restored got their rifles and ammo back and lost their entire
engagement history, silently.

## Root causes

1. **`exportFullBackup` never exported environment snapshots**, but `dope_logs.environment_id`
   is `NOT NULL` with a foreign key — so a restored log had nothing to point at.
2. **Foreign keys were exported verbatim while parents were re-keyed on import.** `id` is
   stripped from every record (correct mass-assignment hardening), so rifles and ammo get new
   `AUTOINCREMENT` ids — but each log still carried the *old* ids.

Both failures were caught per record and logged with `console.error` only, so
`importFullBackup` returned `success: true` with `logsImported: 0`. **That silence is what hid
this for so long**, which is why it's addressed below too.

## Export side

- `exportFullBackup` takes an `environments` argument and includes them in `data` and `counts`.
- **`exportVersion` bumped `1.0` → `1.1`.** The parameter is optional so existing callers still
  compile — but a caller that omits it produces a backup whose logs cannot be restored, which
  is why the call site was updated rather than left to the default.
- `SettingsScreen` calls `loadSnapshots()` before exporting and passes **every** snapshot
  rather than the possibly-truncated list already in the store, and reports the environment
  count in its success message.

## Import side

- Builds `oldId → newId` maps for rifles, ammo and environments as each is created, then
  translates every log's foreign keys before insert. `record.id` is read **only as a lookup
  key** and is still never assigned to a new row, so the hardening is unchanged.
- Imports environments (new `ENVIRONMENT_ALLOWED_FIELDS`) between ammo and logs.
- A log whose parent is missing is **skipped deliberately rather than attempted**. Inserting it
  would either violate a foreign key or — worse — silently attach the log to an unrelated rifle
  whose id happened to collide.
- **`ImportResult` now reports `skipped` counts and `warnings`**, so partial failure is no
  longer indistinguishable from success.
- **Legacy `1.0` files still import their rifles and ammo**, and now say plainly that they
  contain no environment snapshots and their logs cannot be restored — instead of appearing to
  work.

## Tests

The four assertions that documented the defect in #40 are replaced with ones that assert the
fix, plus its failure modes:

| Test | What it pins down |
| --- | --- |
| logs restore | `imported`/`skipped` counts and the actual restored distances |
| **relinking is real** | a decoy rifle is pre-created to take the id the backup used; every restored log must point at the *new* rifle, not the decoy |
| orphaned logs | skipped and reported, not silently dropped |
| legacy 1.0 backup | warns about unrestorable logs |
| parent fails validation | counted as skipped, and takes its logs with it |

The decoy test is the important one — without it, a round trip into an empty database passes
by luck, because auto-increment reproduces the original id sequence.

## Coverage

`ImportService` **59% → 70% statements**.

| metric | before | now | floor |
| --- | --- | --- | --- |
| lines | 27.00% | **28.11%** | 27 |
| statements | 23.47% | **24.60%** | 24 |
| branches | 16.68% | **17.97%** | 17 |
| functions | 20.93% | **21.87%** | 21 |

## Verification

- `npm test` exits 0 — 31 suites, 679 passed / 1 skipped
- `npm run test:coverage` exits 0; all four floors negative-tested individually (each raised
  3pp → exit 1)
- `npm run check` and `npm run type-check` exit 0

## Known gap, deliberately not in scope

`EnvironmentRepository.create` omits `timestamp` from its INSERT, so **restored snapshots are
stamped with the import time, not the original capture time**. I reported this while covering
that repository in #38. It doesn't block log restoration — the FK relinking works regardless —
but it does mean a restored backup loses when each reading was taken. Whether `create()` should
honour a caller-supplied timestamp is a separate decision; say the word and I'll do it.
