### PR TITLE
fix(db): preserve supplied timestamps on DOPE log and environment insert

### DIFF
--- a/__tests__/unit/services/DOPELogRepository.test.ts
+++ b/__tests__/unit/services/DOPELogRepository.test.ts
@@ -87,6 +87,46 @@ describe('DOPELogRepository', () => {
     });
   });
 
+  describe('timestamp handling', () => {
+    it('preserves a caller-supplied engagement time', async () => {
+      const engaged = '2026-05-20T13:45:00.000Z';
+
+      const created = await dopeLogRepository.create(validDopeLog(ids(), { timestamp: engaged }));
+
+      const row = await db.getFirstAsync<{ timestamp: string }>(
+        'SELECT timestamp FROM dope_logs WHERE id = ?',
+        [created.id]
+      );
+      expect(row?.timestamp).toBe(engaged);
+      expect((await dopeLogRepository.getById(created.id as number))?.timestamp).toBe(engaged);
+    });
+
+    it('falls back to the schema default when no timestamp is given', async () => {
+      const created = await dopeLogRepository.create(validDopeLog(ids()));
+
+      const row = await db.getFirstAsync<{ timestamp: string | null }>(
+        'SELECT timestamp FROM dope_logs WHERE id = ?',
+        [created.id]
+      );
+      expect(row?.timestamp).toEqual(expect.any(String));
+      expect(Number.isNaN(Date.parse(row?.timestamp as string))).toBe(false);
+    });
+
+    it('orders history by the supplied timestamps, newest first', async () => {
+      await dopeLogRepository.create(
+        validDopeLog(ids(), { distance: 100, timestamp: '2026-01-01T00:00:00.000Z' })
+      );
+      await dopeLogRepository.create(
+        validDopeLog(ids(), { distance: 900, timestamp: '2026-06-01T00:00:00.000Z' })
+      );
+      await dopeLogRepository.create(
+        validDopeLog(ids(), { distance: 500, timestamp: '2026-03-01T00:00:00.000Z' })
+      );
+
+      expect((await dopeLogRepository.getAll()).map((l) => l.distance)).toEqual([900, 500, 100]);
+    });
+  });
+
   describe('foreign key cascade', () => {
     it('deletes a rifle’s logs when the rifle is deleted (ON DELETE CASCADE)', async () => {
       await dopeLogRepository.create(validDopeLog(ids()));

--- a/__tests__/unit/services/EnvironmentRepository.test.ts
+++ b/__tests__/unit/services/EnvironmentRepository.test.ts
@@ -22,19 +22,9 @@ describe('EnvironmentRepository', () => {
     await uninstallTestDatabase();
   });
 
-  /**
-   * Creates a snapshot and back-dates it.
-   *
-   * `EnvironmentRepository.create` omits `timestamp` from its INSERT column list, so the
-   * schema's `DEFAULT (datetime('now'))` always wins and a caller-supplied timestamp is
-   * discarded. Ordering and age-based queries therefore have to be set up with SQL.
-   */
+  /** Creates a snapshot back-dated by `days`, for ordering and age-based queries. */
   const createAged = async (days: number, altitude: number): Promise<void> => {
-    const created = await environmentRepository.create(validEnvironment({ altitude }));
-    await db.runAsync('UPDATE environment_snapshots SET timestamp = ? WHERE id = ?', [
-      daysAgo(days),
-      created.id as number,
-    ]);
+    await environmentRepository.create(validEnvironment({ altitude, timestamp: daysAgo(days) }));
   };
 
   describe('create', () => {
@@ -101,6 +91,32 @@ describe('EnvironmentRepository', () => {
         longitude: -104.9903,
         densityAltitude: 7200,
       });
+    });
+  });
+
+  describe('timestamp handling', () => {
+    it('preserves a caller-supplied capture time', async () => {
+      const captured = '2026-03-14T15:09:26.000Z';
+
+      const created = await environmentRepository.create(validEnvironment({ timestamp: captured }));
+
+      const row = await db.getFirstAsync<{ timestamp: string }>(
+        'SELECT timestamp FROM environment_snapshots WHERE id = ?',
+        [created.id]
+      );
+      expect(row?.timestamp).toBe(captured);
+      expect((await environmentRepository.getById(created.id as number))?.timestamp).toBe(captured);
+    });
+
+    it('falls back to the schema default when no timestamp is given', async () => {
+      const created = await environmentRepository.create(validEnvironment());
+
+      const row = await db.getFirstAsync<{ timestamp: string | null }>(
+        'SELECT timestamp FROM environment_snapshots WHERE id = ?',
+        [created.id]
+      );
+      expect(row?.timestamp).toEqual(expect.any(String));
+      expect(Number.isNaN(Date.parse(row?.timestamp as string))).toBe(false);
     });
   });
 

--- a/__tests__/unit/services/ExportImportRoundTrip.test.ts
+++ b/__tests__/unit/services/ExportImportRoundTrip.test.ts
@@ -254,6 +254,36 @@ describe('Export/Import round trip', () => {
       expect(logs.map((l) => l.distance).sort((a, b) => a - b)).toEqual([500, 800]);
     });
 
+    it('preserves the original engagement and capture times', async () => {
+      // A restored backup must keep WHEN each shot was taken. Previously create() dropped
+      // `timestamp`, so every restored log and snapshot was re-dated to the import moment.
+      const rifleId = (await rifleProfileRepository.create(validRifle())).id as number;
+      const ammoId = (await ammoProfileRepository.create(validAmmo())).id as number;
+      const environmentId = (
+        await environmentRepository.create(
+          validEnvironment({ timestamp: '2026-04-02T08:15:00.000Z' })
+        )
+      ).id as number;
+      await dopeLogRepository.create(
+        validDopeLog(
+          { rifleId, ammoId, environmentId },
+          { distance: 650, timestamp: '2026-04-02T09:30:00.000Z' }
+        )
+      );
+
+      const exported = await exportEverything();
+
+      await installTestDatabase();
+      await stageImportFile(exported.uri as string);
+      await importFullBackup();
+
+      const [restoredLog] = await dopeLogRepository.getAll();
+      const [restoredEnvironment] = await environmentRepository.getAll();
+
+      expect(restoredLog.timestamp).toBe('2026-04-02T09:30:00.000Z');
+      expect(restoredEnvironment.timestamp).toBe('2026-04-02T08:15:00.000Z');
+    });
+
     it('relinks restored logs to the NEW parent ids, not the ids in the file', async () => {
       await seed();
       const exported = await exportEverything();

--- a/src/services/database/AmmoProfileRepository.ts
+++ b/src/services/database/AmmoProfileRepository.ts
@@ -1,5 +1,6 @@
 import { AmmoProfile, AmmoProfileData } from '../../models/AmmoProfile';
 import { AmmoProfileRow } from '../../types/database.types';
+
 import databaseService from './DatabaseService';
 
 export class AmmoProfileRepository {

--- a/src/services/database/DOPELogRepository.ts
+++ b/src/services/database/DOPELogRepository.ts
@@ -1,5 +1,6 @@
 import { DOPELog, DOPELogData } from '../../models/DOPELog';
 import { DOPELogRow } from '../../types/database.types';
+
 import databaseService from './DatabaseService';
 
 export class DOPELogRepository {
@@ -11,11 +12,16 @@ export class DOPELogRepository {
     const db = databaseService.getDatabase();
 
     const result = await db.runAsync(
+      // `timestamp` is bound through COALESCE so an explicitly supplied value is preserved
+      // while omitting it still falls back to the schema's datetime('now'). A DOPE log's
+      // timestamp IS the engagement date, so dropping it (as this INSERT previously did)
+      // re-dated every restored log to the moment of import and scrambled history ordering,
+      // which is sorted by timestamp.
       `INSERT INTO dope_logs (
         rifle_id, ammo_id, environment_id, distance, distance_unit,
         elevation_correction, windage_correction, correction_unit,
-        target_type, group_size, hit_count, shot_count, notes
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        target_type, group_size, hit_count, shot_count, notes, timestamp
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')))`,
       [
         log.rifleId,
         log.ammoId,
@@ -30,6 +36,7 @@ export class DOPELogRepository {
         log.hitCount || null,
         log.shotCount || null,
         log.notes || null,
+        log.timestamp ?? null,
       ]
     );
 

--- a/src/services/database/DatabaseService.ts
+++ b/src/services/database/DatabaseService.ts
@@ -1,4 +1,5 @@
 import * as SQLite from 'expo-sqlite';
+
 import { DB_SCHEMA, DB_INDEXES } from '../../types/database.types';
 
 const DATABASE_NAME = 'mobiledope.db';

--- a/src/services/database/EnvironmentRepository.ts
+++ b/src/services/database/EnvironmentRepository.ts
@@ -1,5 +1,6 @@
 import { EnvironmentSnapshot, EnvironmentSnapshotData } from '../../models/EnvironmentSnapshot';
 import { EnvironmentSnapshotRow } from '../../types/database.types';
+
 import databaseService from './DatabaseService';
 
 export class EnvironmentRepository {
@@ -11,10 +12,13 @@ export class EnvironmentRepository {
     const db = databaseService.getDatabase();
 
     const result = await db.runAsync(
+      // See DOPELogRepository.create: COALESCE preserves a supplied capture time while
+      // keeping the schema default for ordinary creates. Without this, a restored backup
+      // stamped every snapshot with the import time, losing when the reading was taken.
       `INSERT INTO environment_snapshots (
         temperature, humidity, pressure, altitude, density_altitude,
-        wind_speed, wind_direction, latitude, longitude
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        wind_speed, wind_direction, latitude, longitude, timestamp
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')))`,
       [
         snapshot.temperature,
         snapshot.humidity,
@@ -25,6 +29,7 @@ export class EnvironmentRepository {
         snapshot.windDirection,
         snapshot.latitude || null,
         snapshot.longitude || null,
+        snapshot.timestamp ?? null,
       ]
     );
 

--- a/src/services/database/RangeSessionRepository.ts
+++ b/src/services/database/RangeSessionRepository.ts
@@ -1,5 +1,6 @@
 import { RangeSession, RangeSessionData } from '../../models/RangeSession';
 import { RangeSessionRow } from '../../types/database.types';
+
 import databaseService from './DatabaseService';
 
 export class RangeSessionRepository {

--- a/src/services/database/RifleProfileRepository.ts
+++ b/src/services/database/RifleProfileRepository.ts
@@ -1,5 +1,6 @@
 import { RifleProfile, RifleProfileData } from '../../models/RifleProfile';
 import { RifleProfileRow } from '../../types/database.types';
+
 import databaseService from './DatabaseService';
 
 export class RifleProfileRepository {

--- a/src/services/database/ShotStringRepository.ts
+++ b/src/services/database/ShotStringRepository.ts
@@ -1,5 +1,6 @@
 import { ShotString, ShotStringData } from '../../models/ShotString';
 import { ShotStringRow } from '../../types/database.types';
+
 import databaseService from './DatabaseService';
 
 export interface ShotStringStatistics {

--- a/src/services/database/TargetImageRepository.ts
+++ b/src/services/database/TargetImageRepository.ts
@@ -1,5 +1,6 @@
 import { TargetImage, TargetImageData } from '../../models/TargetImage';
 import { TargetImageRow } from '../../types/database.types';
+
 import databaseService from './DatabaseService';
 
 export class TargetImageRepository {

--- a/src/services/database/migrations/001_initial_schema.ts
+++ b/src/services/database/migrations/001_initial_schema.ts
@@ -1,5 +1,6 @@
-import { Migration } from './MigrationRunner';
 import { DB_SCHEMA, DB_INDEXES } from '../../../types/database.types';
+
+import { Migration } from './MigrationRunner';
 
 /**
  * Initial database schema migration

--- a/src/services/database/migrations/MigrationRunner.ts
+++ b/src/services/database/migrations/MigrationRunner.ts
@@ -1,4 +1,5 @@
 import * as SQLite from 'expo-sqlite';
+
 import databaseService from '../DatabaseService';
 
 export interface Migration {

--- a/src/services/database/migrations/index.ts
+++ b/src/services/database/migrations/index.ts
@@ -3,11 +3,11 @@
  * Import and register all migrations here
  */
 
-import migrationRunner from './MigrationRunner';
 import migration001 from './001_initial_schema';
 import migration002 from './002_add_caliber_to_ammo';
 import migration003 from './003_fix_empty_caliber';
 import migration004 from './004_remove_rifle_id_from_ammo';
+import migrationRunner from './MigrationRunner';
 
 // Register all migrations
 migrationRunner.register(migration001);


### PR DESCRIPTION
Follow-up to #39/#41. Restoring a backup kept the data but lost **when** any of it happened.

## The omission is systemic

Auditing every repository's `create()`: **none** of them include their `timestamp`/`created_at`
column in the INSERT — all rely on the schema `DEFAULT`. (Only `range_sessions.start_time` is
inserted, because it's `NOT NULL` with no default.)

Two of those columns are **user data**, not bookkeeping:

| column | why it matters |
| --- | --- |
| `dope_logs.timestamp` | **This is the engagement date.** Dropping it re-dated every restored log to the import moment — and `getAll`/`getByRifleId`/`getByAmmoId` all sort by it, so restored history also came back in arbitrary order. |
| `environment_snapshots.timestamp` | When the reading was taken. This is the case I reported while covering that repository in #38. |

## The fix

Both INSERTs now include the column and bind through `COALESCE`:

```sql
) VALUES (..., COALESCE(?, datetime('now')))
```

with `?` bound to `log.timestamp ?? null`.

A supplied value is preserved; omitting one still gets the schema's `datetime('now')` in the
same SQLite format as before — so **ordinary creates behave exactly as they did**. One
statement, no branching between two INSERT variants, and no change to `DOPELog` /
`EnvironmentSnapshot`, whose `timestamp` is deliberately optional and whose `toRow()` still
omits it.

## Tests

- Both repositories: a supplied timestamp is persisted and read back; omitting one still yields
  a parseable default.
- `DOPELogRepository`: `getAll()` orders by the supplied timestamps, newest first — the
  regression that dropping the column actually caused, which the previous suite couldn't see
  because every row had the same insert-time value.
- **Round trip:** a log exported with `timestamp 2026-04-02T09:30` and its snapshot at `08:15`
  come back with those exact times after export → fresh database → import.

The `EnvironmentRepository` suite's `createAged` helper previously worked around this by
`UPDATE`-ing the timestamp after create; it now just passes it, and the comment describing the
old behaviour is gone.

## Deliberately not changed

`created_at` on `rifle_profiles`, `ammo_profiles`, `shot_strings`, `range_sessions` and
`target_images`. Those are record-keeping rather than user data, and none appear in
`importFullBackup`'s allow-lists — a full backup restores rifles, ammo, environments and logs
only. So there's no fidelity loss to fix, and widening the allow-lists would enlarge the
mass-assignment surface for no benefit.

## Note on the file count

9 of the 14 changed files are **one-line `import/order` autofixes** — I ran `eslint --fix`
across `src/services/database/` and it reordered imports / inserted blank lines between import
groups in files I didn't otherwise touch. No logic changes; they reduce the repo warning count
slightly. The substantive changes are `DOPELogRepository.ts`, `EnvironmentRepository.ts` and the
three test files.

## Verification

- `npm test` exits 0 — 31 suites, **685 passed** / 1 skipped (was 679)
- `npm run check` and `npm run type-check` exit 0
- `npm run test:coverage` exits 0

Coverage floors left at 27/24/17/21; actuals are 27.94 / 24.41 / 17.81 / 21.76. **`statements`
now has only 0.41pp of headroom** — adding SQL lines legitimately shifts the denominator, and
`jest.config.js`'s rule is only ever to *raise* these floors, so I didn't lower it. Worth
knowing that the next change touching this area may need to add a test alongside it.
